### PR TITLE
Work with 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2021-10-13
+### Added
+- Removed the Literal from python 3.8 and added Literal from typing_extensions package. Now supertokens_python can be used with python 3.7 .
+
+
 ## [0.0.3] - 2021-10-13
 ### Added
 - Adds OAuth development keys for Google and Github for faster recipe implementation.

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,12 @@ extras_require = {
         'pytest-asyncio==0.14.0',
         'respx==0.16.3',
         'nest-asyncio==1.5.1',
-        'Fastapi>=0.60',
+        'Fastapi==0.68.1',
         'django',
         'Flask==2.0.1',
         'python-dotenv',
-        'flask_cors'
+        'flask_cors',
+        'django-cors-headers'
     ])
 }
 
@@ -71,8 +72,9 @@ setup(
         "tldextract==3.1.0",
         "asgiref==3.4.1",
         "werkzeug==2.0.1",
-        'starlette~=0.14.2'
+        'starlette~=0.14.2',
+        'typing_extensions==3.10'
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     extras_require=extras_require
 )

--- a/supertokens_python/recipe/emailpassword/interfaces.py
+++ b/supertokens_python/recipe/emailpassword/interfaces.py
@@ -16,7 +16,12 @@ under the License.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union, TYPE_CHECKING, Literal, List
+from typing import Union, TYPE_CHECKING, List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from supertokens_python.framework import BaseRequest, BaseResponse

--- a/supertokens_python/recipe/emailpassword/recipe_implementation.py
+++ b/supertokens_python/recipe/emailpassword/recipe_implementation.py
@@ -15,7 +15,12 @@ under the License.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union, Literal
+from typing import TYPE_CHECKING, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .interfaces import (
     RecipeInterface, SignInOkResult, SignInWrongCredentialsErrorResult, SignUpOkResult,

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -16,7 +16,12 @@ under the License.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union, TYPE_CHECKING, Literal
+from typing import Union, TYPE_CHECKING
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from supertokens_python.framework import BaseRequest, BaseResponse

--- a/supertokens_python/recipe/session/cookie_and_header.py
+++ b/supertokens_python/recipe/session/cookie_and_header.py
@@ -15,7 +15,13 @@ under the License.
 """
 from __future__ import annotations
 
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from urllib.parse import quote, unquote
 
 from .constants import (

--- a/supertokens_python/recipe/thirdparty/recipe_implementation.py
+++ b/supertokens_python/recipe/thirdparty/recipe_implementation.py
@@ -15,7 +15,12 @@ under the License.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union, Literal, List
+from typing import TYPE_CHECKING, Union, List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from supertokens_python.normalised_url_path import NormalisedURLPath
 

--- a/supertokens_python/recipe/thirdpartyemailpassword/interfaces.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/interfaces.py
@@ -1,5 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Union, List, Literal
+from typing import Union, List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from supertokens_python.recipe.emailpassword.interfaces import CreateResetPasswordResult, ResetPasswordUsingTokenResult, \
     UpdateEmailOrPasswordResult, SignInResult, SignUpResult, EmailExistsGetResponse, \

--- a/supertokens_python/recipe/thirdpartyemailpassword/types.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/types.py
@@ -13,7 +13,12 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations
 under the License.
 """
-from typing import Union, List, Literal
+from typing import Union, List
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from supertokens_python.recipe.emailpassword.types import FormField
 
 type_string = {

--- a/supertokens_python/recipe_module.py
+++ b/supertokens_python/recipe_module.py
@@ -17,7 +17,12 @@ under the License.
 from __future__ import annotations
 
 import abc
-from typing import Union, Literal, List, TYPE_CHECKING
+from typing import Union, List, TYPE_CHECKING
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .framework.response import BaseResponse
 


### PR DESCRIPTION
## Summary of change

Literal is supported in python  >= 3.8. To support 3.7 it was added Literal from typing_extensions which can work with python 3.7. 


## Test Plan

I ran fastapi frontendintegration tests in a new enviroment with python 3.7 and with the new changes.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had run `make lint`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable

## Remaining TODOs for this PR
