### PR TITLE
fix: separates out installation for tests and fixes dependencies on frameworks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-fastapi
       - run: (cd .circleci/ && ./websiteFastApi.sh)
       - slack/status
   test-website-flask:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-flask
       - run: (cd .circleci/ && ./websiteFlask.sh)
       - slack/status
   test-website-django:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-django
       - run: (cd .circleci/ && ./websiteDjango.sh)
       - slack/status
   test-authreact-fastapi:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-fastapi
       - run: (cd .circleci/ && ./authReactFastApi.sh)
       - slack/status
   test-authreact-flask:
@@ -75,7 +75,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-flask
       - run: (cd .circleci/ && ./authReactFlask.sh)
       - slack/status
   test-authreact-django:
@@ -85,7 +85,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-django
       - run: (cd .circleci/ && ./authReactDjango.sh)
       - slack/status
   test-success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.5.1] - 2022-03-02
+
+### Fixes:
+- Bug where a user had to add dependencies on all frameworks when using the SDK: https://github.com/supertokens/supertokens-python/issues/82
+
 ## [0.5.0] - 2022-02-03
 
 ### Breaking Change

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,16 @@ test:
 	pytest ./tests/
 
 dev-install:
-	pip3 install -e .[dev]
+	pip3 install -e .[dev] && pip3 install -e .[fastapi] && pip3 install -e .[django] && pip3 install -e .[flask]
+
+dev-install-with-fastapi:
+	pip3 install -e .[dev] && pip3 install -e .[fastapi]
+
+dev-install-with-django:
+	pip3 install -e .[dev] && pip3 install -e .[django]
+
+dev-install-with-flask:
+	pip3 install -e .[dev] && pip3 install -e .[flask]
 
 build-docs:
 	rm -rf html && pdoc --html supertokens_python

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.5.0",
+    version="0.5.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.io",

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,25 @@ extras_require = {
         'uvicorn==0.13.4',
         'requests==2.25.1',
         'pytest-asyncio==0.14.0',
-        'respx==0.16.3',
         'nest-asyncio==1.5.1',
-        'Fastapi==0.68.1',
-        'django==3.2.12',
-        'Flask==2.0.2',
         'python-dotenv==0.19.2',
-        'flask_cors',
-        'django-cors-headers==3.11.0',
         'pdoc3==0.10.0',
         'tzdata==2021.5',
         'pylint==2.12.2',
         'isort==5.10.1',
         'pyright==0.0.13',
+    ]),
+    'fastapi': ([
+        'respx==0.16.3',
+        'Fastapi==0.68.1'
+    ]),
+    'flask': ([
+        'flask_cors',
+        'Flask==2.0.2'
+    ]),
+    'django': ([
+        'django-cors-headers==3.11.0',
+        'django==3.2.12',
         'django-stubs==1.9.0'
     ])
 }

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12']
-VERSION = '0.5.0'
+VERSION = '0.5.1'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'

--- a/supertokens_python/framework/django/framework.py
+++ b/supertokens_python/framework/django/framework.py
@@ -12,12 +12,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from supertokens_python.framework.django.django_request import DjangoRequest
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 
 class DjangoFramework(Framework):
-    from django.http import HttpRequest
 
     def wrap_request(self, unwrapped: HttpRequest):
+        from supertokens_python.framework.django.django_request import \
+            DjangoRequest
         return DjangoRequest(unwrapped)

--- a/supertokens_python/framework/fastapi/fastapi_middleware.py
+++ b/supertokens_python/framework/fastapi/fastapi_middleware.py
@@ -11,16 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from starlette.middleware.base import (BaseHTTPMiddleware,
                                        RequestResponseEndpoint)
 from supertokens_python.framework import BaseResponse
 
+if TYPE_CHECKING:
+    from fastapi import FastAPI, Request
+
 
 class Middleware(BaseHTTPMiddleware):
-    from fastapi import FastAPI, Request
 
     def __init__(self, app: FastAPI):
         super().__init__(app)

--- a/supertokens_python/framework/fastapi/framework.py
+++ b/supertokens_python/framework/fastapi/framework.py
@@ -11,13 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from supertokens_python.framework.fastapi.fastapi_request import FastApiRequest
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 
 class FastapiFramework(Framework):
-    from fastapi import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.fastapi.fastapi_request import \
+            FastApiRequest
         return FastApiRequest(unwrapped)

--- a/supertokens_python/framework/flask/flask_middleware.py
+++ b/supertokens_python/framework/flask/flask_middleware.py
@@ -11,16 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import json
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from supertokens_python.async_to_sync_wrapper import sync
 from supertokens_python.framework import BaseResponse
 
+if TYPE_CHECKING:
+    from flask import Flask
+
 
 class Middleware:
-    from flask import Flask
 
     def __init__(self, app: Flask):
         self.app = app

--- a/supertokens_python/framework/flask/framework.py
+++ b/supertokens_python/framework/flask/framework.py
@@ -11,13 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from supertokens_python.framework.flask.flask_request import FlaskRequest
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from flask.wrappers import Request
 
 
 class FlaskFramework(Framework):
-    from flask.wrappers import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.flask.flask_request import \
+            FlaskRequest
         return FlaskRequest(unwrapped)

--- a/supertokens_python/recipe/thirdparty/providers/apple.py
+++ b/supertokens_python/recipe/thirdparty/providers/apple.py
@@ -141,8 +141,7 @@ class Apple(Provider):
         err = Exception("Id token verification failed")
         for key in public_keys:
             try:
-                decode(jwt=token, key=key,
-                       audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=["RS256"])
+                decode(jwt=token, key=key, audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=["RS256"])  # type: ignore
                 return
             except Exception as e:
                 err = e


### PR DESCRIPTION
## Summary of change

FIxes a bug where all frameworks dependencies needed to be added by the user.

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/82

## Test Plan

Added separate installation steps for each framework which is run when running auth-react and website tests

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
