### PR TITLE
refactor!: Modified all recipe interfaces to have exact return types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Breaking Change
-- Refactored emailverify recipe interfaces.
+- Refactored emailverify recipe interfaces towards fixing issue https://github.com/supertokens/supertokens-python/issues/75
 
 ### Addition
 - Added docstrings emailverify recipe interfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Breaking Change
-- Refactored EmailVerifyPostOkResponse and EmailVerifyPostInvalidTokenErrorResponse classes under recipe.emailvarification.interfaces.
-- Removed EmailVerifyPostResponse class.
+- Refactored emailverify recipe interfaces.
 
 ### Addition
-- Added docstrings in EmailVerifyPostOkResponse, EmailVerifyPostInvalidTokenErrorResponse and email_verify_post method for email varification.
+- Added docstrings emailverify recipe interfaces.
 
 ### Fixes:
 - Bug where a user had to add dependencies on all frameworks when using the SDK: https://github.com/supertokens/supertokens-python/issues/82

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.5.1] - 2022-03-02
+### Breaking Change
+- Refactored EmailVerifyPostOkResponse and EmailVerifyPostInvalidTokenErrorResponse classes under recipe.emailvarification.interfaces.
+- Removed EmailVerifyPostResponse class.
+
+### Addition
+- Added docstrings in EmailVerifyPostOkResponse, EmailVerifyPostInvalidTokenErrorResponse and email_verify_post method for email varification.
 
 ### Fixes:
 - Bug where a user had to add dependencies on all frameworks when using the SDK: https://github.com/supertokens/supertokens-python/issues/82

--- a/supertokens_python/recipe/emailverification/api/implementation.py
+++ b/supertokens_python/recipe/emailverification/api/implementation.py
@@ -32,25 +32,27 @@ from supertokens_python.recipe.session.asyncio import get_session
 
 class APIImplementation(APIInterface):
     async def email_verify_post(self, token: str, api_options: APIOptions, user_context: Dict[str, Any]) -> Union[EmailVerifyPostOkResponse, EmailVerifyPostInvalidTokenErrorResponse]:
-        """email_verify_post:
-            async method:
-                accepts:
-                    - token: string,
-                    - api_options: APIOptions,
-                    - user_context: python dict
-                returns
-                    EmailVerifyPostResponse: if the user is successfully varified, the response could be as follows
-                        {
-                            "status": "OK",
-                            "user": {
-                              "id": "<usern-id>",
-                              "email": "<email-id>"
-                        }
-                    EmailVerifyPostInvalidTokenErrorResponse: If the token is invalid and the user is not varified,
-                        the response could be as follows:
-                        {
-                            "status": "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR"
-                        }
+        """email_verify_post is an async mehtod that accepts
+
+               - token: string,
+               - api_options: APIOptions,
+               - user_context: python dict
+
+            if the user is successfully varified, the response could be as follows
+
+                {
+                    "status": "OK",
+                    "user": {
+                      "id": "<usern-id>",
+                      "email": "<email-id>"
+                }
+
+            If the token is invalid and the user is not varified,
+            the response could be as follows:
+
+                {
+                    "status": "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR"
+                }
         """
         response = await api_options.recipe_implementation.verify_email_using_token(token, user_context)
         if response.user:

--- a/supertokens_python/recipe/emailverification/api/implementation.py
+++ b/supertokens_python/recipe/emailverification/api/implementation.py
@@ -13,7 +13,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from supertokens_python.recipe.emailverification.interfaces import (
     APIInterface, EmailVerifyPostInvalidTokenErrorResponse,
@@ -23,7 +23,7 @@ from supertokens_python.recipe.emailverification.interfaces import (
 
 if TYPE_CHECKING:
     from supertokens_python.recipe.emailverification.interfaces import (
-        APIOptions, GenerateEmailVerifyTokenPostResponse, IsEmailVerifiedGetResponse, EmailVerifyPostResponse
+        APIOptions, GenerateEmailVerifyTokenPostResponse, IsEmailVerifiedGetResponse
     )
 
 from supertokens_python.recipe.emailverification.types import User
@@ -31,11 +31,29 @@ from supertokens_python.recipe.session.asyncio import get_session
 
 
 class APIImplementation(APIInterface):
-    async def email_verify_post(self, token: str, api_options: APIOptions, user_context: Dict[str, Any]) -> EmailVerifyPostResponse:
+    async def email_verify_post(self, token: str, api_options: APIOptions, user_context: Dict[str, Any]) -> Union[EmailVerifyPostOkResponse, EmailVerifyPostInvalidTokenErrorResponse]:
+        """email_verify_post:
+            async method:
+                accepts:
+                    - token: string,
+                    - api_options: APIOptions,
+                    - user_context: python dict
+                returns
+                    EmailVerifyPostResponse: if the user is successfully varified, the response could be as follows
+                        {
+                            "status": "OK",
+                            "user": {
+                              "id": "<usern-id>",
+                              "email": "<email-id>"
+                        }
+                    EmailVerifyPostInvalidTokenErrorResponse: If the token is invalid and the user is not varified,
+                        the response could be as follows:
+                        {
+                            "status": "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR"
+                        }
+        """
         response = await api_options.recipe_implementation.verify_email_using_token(token, user_context)
-        if response.is_ok:
-            if response.user is None:
-                raise Exception("Should never come here")
+        if response.user:
             return EmailVerifyPostOkResponse(response.user)
         return EmailVerifyPostInvalidTokenErrorResponse()
 

--- a/supertokens_python/recipe/emailverification/api/implementation.py
+++ b/supertokens_python/recipe/emailverification/api/implementation.py
@@ -55,8 +55,9 @@ class APIImplementation(APIInterface):
                 }
         """
         response = await api_options.recipe_implementation.verify_email_using_token(token, user_context)
-        if response.user:
-            return EmailVerifyPostOkResponse(response.user)
+        if response.is_ok:
+            if response.user:
+                return EmailVerifyPostOkResponse(response.user)
         return EmailVerifyPostInvalidTokenErrorResponse()
 
     async def is_email_verified_get(self, api_options: APIOptions, user_context: Dict[str, Any]) -> IsEmailVerifiedGetResponse:

--- a/supertokens_python/recipe/emailverification/api/implementation.py
+++ b/supertokens_python/recipe/emailverification/api/implementation.py
@@ -93,6 +93,25 @@ class APIImplementation(APIInterface):
         raise Exception("Undefined Session")
 
     async def generate_email_verify_token_post(self, api_options: APIOptions, user_context: Dict[str, Any]) -> GenerateEmailVerifyTokenPostResponse:
+        """
+        generate_email_verify_token_post is an async method that accepts
+
+            - api_options: APIOptions
+            - user_context: Dict
+
+        returns a json/dict response as follows
+
+        In the case of success:
+
+            {
+                "status": "OK"
+            }
+
+        In the case of failure:
+            {
+                "status": "EMAIL_ALREADY_VERIFIED_ERROR"
+            }
+        """
         session = await get_session(api_options.request)
         if isinstance(session, SessionContainer):
             user_id = session.get_user_id(user_context)

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Union
 
+from supertokens_python.types import APIResponse
 from typing_extensions import Literal
-
-from .types import STResponse
 
 if TYPE_CHECKING:
     from supertokens_python.framework import BaseRequest, BaseResponse
@@ -135,13 +134,7 @@ class APIOptions:
         self.recipe_implementation = recipe_implementation
 
 
-class EmailVerifyPostResponse(STResponse):
-    # TODO: This is a placeholder class for now, need to figure out
-    # correct hirarchy for Response class from supertokens
-    pass
-
-
-class EmailVerifyPostOkResponse(EmailVerifyPostResponse):
+class EmailVerifyPostOkResponse(APIResponse):
     """
     EmailVerifyPostOkResponse: used to send the ok response if the user
     is successfully verified.
@@ -160,7 +153,7 @@ class EmailVerifyPostOkResponse(EmailVerifyPostResponse):
         }
 
 
-class EmailVerifyPostInvalidTokenErrorResponse(EmailVerifyPostResponse):
+class EmailVerifyPostInvalidTokenErrorResponse(APIResponse):
     """
     EmailVerifyPostInvalidTokenErrorResponse: used to send the error response if the
     user varification fails due to invalid token.

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -59,28 +59,14 @@ class VerifyEmailUsingTokenInvalidTokenErrorResult:
     pass
 
 
-class RevokeEmailVerificationTokensResult(ABC):
-    def __init__(self, status: Literal['OK']):
-        self.status = status
+class RevokeEmailVerificationTokensOkResult:
+    # TODO: add test cases
+    pass
 
 
-class RevokeEmailVerificationTokensOkResult(
-        RevokeEmailVerificationTokensResult):
-    def __init__(self):
-        super().__init__('OK')
-        self.is_ok = True
-
-
-class UnverifyEmailResult(ABC):
-    def __init__(self, status: Literal['OK']):
-        self.status = status
-        self.is_ok = False
-
-
-class UnverifyEmailOkResult(UnverifyEmailResult):
-    def __init__(self):
-        super().__init__('OK')
-        self.is_ok = True
+class UnverifyEmailOkResult:
+    # TODO: add test cases
+    pass
 
 
 class RecipeInterface(ABC):
@@ -100,11 +86,11 @@ class RecipeInterface(ABC):
         pass
 
     @abstractmethod
-    async def revoke_email_verification_tokens(self, user_id: str, email: str, user_context: Dict[str, Any]) -> RevokeEmailVerificationTokensResult:
+    async def revoke_email_verification_tokens(self, user_id: str, email: str, user_context: Dict[str, Any]) -> RevokeEmailVerificationTokensOkResult:
         pass
 
     @abstractmethod
-    async def unverify_email(self, user_id: str, email: str, user_context: Dict[str, Any]) -> UnverifyEmailResult:
+    async def unverify_email(self, user_id: str, email: str, user_context: Dict[str, Any]) -> UnverifyEmailOkResult:
         pass
 
 

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -52,14 +52,11 @@ class CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult(
 
 class VerifyEmailUsingTokenOkResult:
     def __init__(self, user: User):
-        self.status = 'OK'
         self.user = user
 
 
 class VerifyEmailUsingTokenInvalidTokenErrorResult:
-    def __init__(self):
-        self.status = 'EMAIL_VERIFICATION_INVALID_TOKEN_ERROR'
-        self.user = None
+    pass
 
 
 class RevokeEmailVerificationTokensResult(ABC):
@@ -129,10 +126,11 @@ class EmailVerifyPostOkResponse(APIResponse):
 
     def __init__(self, user: User):
         self.user = user
+        self.status = "OK"
 
     def to_json(self) -> Dict[str, Any]:
         return {
-            'status': "OK",
+            'status': self.status,
             'user': {
                 'id': self.user.user_id,
                 'email': self.user.email
@@ -146,9 +144,12 @@ class EmailVerifyPostInvalidTokenErrorResponse(APIResponse):
     user varification fails due to invalid token.
     """
 
+    def __init__(self):
+        self.status = "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR"
+
     def to_json(self) -> Dict[str, Any]:
         return {
-            'status': 'EMAIL_VERIFICATION_INVALID_TOKEN_ERROR'
+            'status': self.status
         }
 
 

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 
 from typing_extensions import Literal
 
+from .types import STResponse
+
 if TYPE_CHECKING:
     from supertokens_python.framework import BaseRequest, BaseResponse
 
@@ -133,10 +135,10 @@ class APIOptions:
         self.recipe_implementation = recipe_implementation
 
 
-class EmailVerifyPostResponse(ABC):
-    @abstractmethod
-    def to_json(self) -> Dict[str, Any]:
-        pass
+class EmailVerifyPostResponse(STResponse):
+    # TODO: This is a placeholder class for now, need to figure out
+    # correct hirarchy for Response class from supertokens
+    pass
 
 
 class EmailVerifyPostOkResponse(EmailVerifyPostResponse):

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -54,22 +54,17 @@ class VerifyEmailUsingTokenOkResult:
     def __init__(self, user: User):
         self.status = 'OK'
         self.user = user
-        self.is_ok = True
-        self.is_email_verification_invalid_token_error = False
 
 
 class VerifyEmailUsingTokenInvalidTokenErrorResult:
     def __init__(self):
         self.status = 'EMAIL_VERIFICATION_INVALID_TOKEN_ERROR'
         self.user = None
-        self.is_ok = False
-        self.is_email_verification_invalid_token_error = True
 
 
 class RevokeEmailVerificationTokensResult(ABC):
     def __init__(self, status: Literal['OK']):
         self.status = status
-        self.is_ok = False
 
 
 class RevokeEmailVerificationTokensOkResult(
@@ -161,7 +156,6 @@ class IsEmailVerifiedGetOkResponse(APIResponse):
     def __init__(self, is_verified: bool):
         self.status = 'OK'
         self.is_verified = is_verified
-        self.is_ok = True
 
     def to_json(self) -> Dict[str, Any]:
         return {
@@ -170,10 +164,10 @@ class IsEmailVerifiedGetOkResponse(APIResponse):
         }
 
 
-class GenerateEmailVerifyTokenPostResponse(ABC):
-    def __init__(self, status: Literal['OK', 'EMAIL_ALREADY_VERIFIED_ERROR']):
-        self.status = status
-        self.is_ok = False
+class GenerateEmailVerifyTokenPostOkResponse(
+        APIResponse):
+    def __init__(self):
+        self.status = 'OK'
         self.is_email_already_verified_error = False
 
     def to_json(self) -> Dict[str, Any]:
@@ -182,20 +176,15 @@ class GenerateEmailVerifyTokenPostResponse(ABC):
         }
 
 
-class GenerateEmailVerifyTokenPostOkResponse(
-        GenerateEmailVerifyTokenPostResponse):
-    def __init__(self):
-        super().__init__('OK')
-        self.is_ok = True
-        self.is_email_already_verified_error = False
-
-
 class GenerateEmailVerifyTokenPostEmailAlreadyVerifiedErrorResponse(
-        GenerateEmailVerifyTokenPostResponse):
+        APIResponse):
     def __init__(self):
-        super().__init__('EMAIL_ALREADY_VERIFIED_ERROR')
-        self.is_ok = False
-        self.is_email_already_verified_error = True
+        self.status = 'EMAIL_ALREADY_VERIFIED_ERROR'
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'status': self.status
+        }
 
 
 class APIInterface(ABC):
@@ -214,5 +203,5 @@ class APIInterface(ABC):
 
     @abstractmethod
     async def generate_email_verify_token_post(self, api_options: APIOptions,
-                                               user_context: Dict[str, Any]) -> GenerateEmailVerifyTokenPostResponse:
+                                               user_context: Dict[str, Any]) -> Union[GenerateEmailVerifyTokenPostOkResponse, GenerateEmailVerifyTokenPostEmailAlreadyVerifiedErrorResponse]:
         pass

--- a/supertokens_python/recipe/emailverification/interfaces.py
+++ b/supertokens_python/recipe/emailverification/interfaces.py
@@ -50,26 +50,18 @@ class CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult(
         self.is_email_already_verified = True
 
 
-class VerifyEmailUsingTokenResult(ABC):
-    def __init__(
-            self, status: Literal['OK', 'EMAIL_VERIFICATION_INVALID_TOKEN_ERROR'], user: Union[User, None]):
-        self.status = status
-        self.is_ok = False
-        self.is_email_verification_invalid_token_error = False
-        self.user = user
-
-
-class VerifyEmailUsingTokenOkResult(VerifyEmailUsingTokenResult):
+class VerifyEmailUsingTokenOkResult:
     def __init__(self, user: User):
-        super().__init__('OK', user)
+        self.status = 'OK'
+        self.user = user
         self.is_ok = True
         self.is_email_verification_invalid_token_error = False
 
 
-class VerifyEmailUsingTokenInvalidTokenErrorResult(
-        VerifyEmailUsingTokenResult):
+class VerifyEmailUsingTokenInvalidTokenErrorResult:
     def __init__(self):
-        super().__init__('EMAIL_VERIFICATION_INVALID_TOKEN_ERROR', None)
+        self.status = 'EMAIL_VERIFICATION_INVALID_TOKEN_ERROR'
+        self.user = None
         self.is_ok = False
         self.is_email_verification_invalid_token_error = True
 
@@ -104,11 +96,11 @@ class RecipeInterface(ABC):
         pass
 
     @abstractmethod
-    async def create_email_verification_token(self, user_id: str, email: str, user_context: Dict[str, Any]) -> CreateEmailVerificationTokenResult:
+    async def create_email_verification_token(self, user_id: str, email: str, user_context: Dict[str, Any]) -> Union[CreateEmailVerificationTokenOkResult, CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult]:
         pass
 
     @abstractmethod
-    async def verify_email_using_token(self, token: str, user_context: Dict[str, Any]) -> VerifyEmailUsingTokenResult:
+    async def verify_email_using_token(self, token: str, user_context: Dict[str, Any]) -> Union[VerifyEmailUsingTokenOkResult, VerifyEmailUsingTokenInvalidTokenErrorResult]:
         pass
 
     @abstractmethod
@@ -165,20 +157,9 @@ class EmailVerifyPostInvalidTokenErrorResponse(APIResponse):
         }
 
 
-class IsEmailVerifiedGetResponse(ABC):
-    def __init__(self, status: Literal['OK']):
-        self.status = status
-        self.is_ok = False
-
-    def to_json(self) -> Dict[str, Any]:
-        return {
-            'status': self.status
-        }
-
-
-class IsEmailVerifiedGetOkResponse(IsEmailVerifiedGetResponse):
+class IsEmailVerifiedGetOkResponse(APIResponse):
     def __init__(self, is_verified: bool):
-        super().__init__('OK')
+        self.status = 'OK'
         self.is_verified = is_verified
         self.is_ok = True
 
@@ -228,7 +209,7 @@ class APIInterface(ABC):
         pass
 
     @abstractmethod
-    async def is_email_verified_get(self, api_options: APIOptions, user_context: Dict[str, Any]) -> IsEmailVerifiedGetResponse:
+    async def is_email_verified_get(self, api_options: APIOptions, user_context: Dict[str, Any]) -> IsEmailVerifiedGetOkResponse:
         pass
 
     @abstractmethod

--- a/supertokens_python/recipe/emailverification/recipe_implementation.py
+++ b/supertokens_python/recipe/emailverification/recipe_implementation.py
@@ -20,8 +20,7 @@ from supertokens_python.normalised_url_path import NormalisedURLPath
 from .interfaces import (
     CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult,
     CreateEmailVerificationTokenOkResult, RecipeInterface,
-    RevokeEmailVerificationTokensOkResult, RevokeEmailVerificationTokensResult,
-    UnverifyEmailOkResult, UnverifyEmailResult,
+    RevokeEmailVerificationTokensOkResult, UnverifyEmailOkResult,
     VerifyEmailUsingTokenInvalidTokenErrorResult,
     VerifyEmailUsingTokenOkResult)
 from .types import User
@@ -67,7 +66,7 @@ class RecipeImplementation(RecipeInterface):
         response = await self.querier.send_get_request(NormalisedURLPath('/recipe/user/email/verify'), params)
         return response['isVerified']
 
-    async def revoke_email_verification_tokens(self, user_id: str, email: str, user_context: Dict[str, Any]) -> RevokeEmailVerificationTokensResult:
+    async def revoke_email_verification_tokens(self, user_id: str, email: str, user_context: Dict[str, Any]) -> RevokeEmailVerificationTokensOkResult:
         data = {
             'userId': user_id,
             'email': email
@@ -75,7 +74,7 @@ class RecipeImplementation(RecipeInterface):
         await self.querier.send_post_request(NormalisedURLPath('/recipe/user/email/verify/token/remove'), data)
         return RevokeEmailVerificationTokensOkResult()
 
-    async def unverify_email(self, user_id: str, email: str, user_context: Dict[str, Any]) -> UnverifyEmailResult:
+    async def unverify_email(self, user_id: str, email: str, user_context: Dict[str, Any]) -> UnverifyEmailOkResult:
         data = {
             'userId': user_id,
             'email': email

--- a/supertokens_python/recipe/emailverification/recipe_implementation.py
+++ b/supertokens_python/recipe/emailverification/recipe_implementation.py
@@ -13,17 +13,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from supertokens_python.normalised_url_path import NormalisedURLPath
 
 from .interfaces import (
     CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult,
-    CreateEmailVerificationTokenOkResult, CreateEmailVerificationTokenResult,
-    RecipeInterface, RevokeEmailVerificationTokensOkResult,
-    RevokeEmailVerificationTokensResult, UnverifyEmailOkResult,
-    UnverifyEmailResult, VerifyEmailUsingTokenInvalidTokenErrorResult,
-    VerifyEmailUsingTokenOkResult, VerifyEmailUsingTokenResult)
+    CreateEmailVerificationTokenOkResult, RecipeInterface,
+    RevokeEmailVerificationTokensOkResult, RevokeEmailVerificationTokensResult,
+    UnverifyEmailOkResult, UnverifyEmailResult,
+    VerifyEmailUsingTokenInvalidTokenErrorResult,
+    VerifyEmailUsingTokenOkResult)
 from .types import User
 
 if TYPE_CHECKING:
@@ -38,7 +38,7 @@ class RecipeImplementation(RecipeInterface):
         self.querier = querier
         self.config = config
 
-    async def create_email_verification_token(self, user_id: str, email: str, user_context: Dict[str, Any]) -> CreateEmailVerificationTokenResult:
+    async def create_email_verification_token(self, user_id: str, email: str, user_context: Dict[str, Any]) -> Union[CreateEmailVerificationTokenOkResult, CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult]:
         data = {
             'userId': user_id,
             'email': email
@@ -48,7 +48,7 @@ class RecipeImplementation(RecipeInterface):
             return CreateEmailVerificationTokenOkResult(response['token'])
         return CreateEmailVerificationTokenEmailAlreadyVerifiedErrorResult()
 
-    async def verify_email_using_token(self, token: str, user_context: Dict[str, Any]) -> VerifyEmailUsingTokenResult:
+    async def verify_email_using_token(self, token: str, user_context: Dict[str, Any]) -> Union[VerifyEmailUsingTokenOkResult, VerifyEmailUsingTokenInvalidTokenErrorResult]:
         data = {
             'method': 'token',
             'token': token

--- a/supertokens_python/recipe/emailverification/types.py
+++ b/supertokens_python/recipe/emailverification/types.py
@@ -12,8 +12,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
 
 class User:
     def __init__(self, user_id: str, email: str):
         self.user_id = user_id
         self.email = email
+
+
+class STResponse(ABC):
+    """
+    Base class for all of the responses (POST and GET) from supertokens.
+    """
+    @abstractmethod
+    def to_json(self) -> Dict[str, Any]:
+        pass

--- a/supertokens_python/recipe/emailverification/types.py
+++ b/supertokens_python/recipe/emailverification/types.py
@@ -11,7 +11,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
 class User:
     def __init__(self, user_id: str, email: str):
         self.user_id = user_id

--- a/supertokens_python/recipe/emailverification/types.py
+++ b/supertokens_python/recipe/emailverification/types.py
@@ -12,20 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from abc import ABC, abstractmethod
-from typing import Any, Dict
-
-
 class User:
     def __init__(self, user_id: str, email: str):
         self.user_id = user_id
         self.email = email
-
-
-class STResponse(ABC):
-    """
-    Base class for all of the responses (POST and GET) from supertokens.
-    """
-    @abstractmethod
-    def to_json(self) -> Dict[str, Any]:
-        pass

--- a/supertokens_python/types.py
+++ b/supertokens_python/types.py
@@ -11,7 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import List, Union
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Union
 
 
 class ThirdPartyInfo:
@@ -35,3 +36,12 @@ class UsersResponse:
                  next_pagination_token: Union[str, None]):
         self.users: List[User] = users
         self.next_pagination_token: Union[str, None] = next_pagination_token
+
+
+class APIResponse(ABC):
+    """
+    Base class for all of the responses (POST and GET) from supertokens.
+    """
+    @abstractmethod
+    def to_json(self) -> Dict[str, Any]:
+        pass

--- a/tests/emailpassword/test_emailverify.py
+++ b/tests/emailpassword/test_emailverify.py
@@ -29,7 +29,7 @@ from supertokens_python.recipe.emailpassword.asyncio import (
     revoke_email_verification_token, unverify_email, verify_email_using_token)
 from supertokens_python.recipe.emailpassword.types import User
 from supertokens_python.recipe.emailverification.interfaces import (
-    APIInterface, APIOptions)
+    APIInterface, APIOptions, EmailVerifyPostOkResponse)
 from supertokens_python.recipe.emailverification.types import User as EVUser
 from supertokens_python.recipe.emailverification.utils import OverrideConfig
 from supertokens_python.recipe.session import SessionContainer
@@ -551,7 +551,7 @@ async def test_that_the_handle_post_email_verification_callback_is_called_on_suc
 
             response = await temp(token, api_options, user_context)
 
-            if response.status == "OK":
+            if isinstance(response, EmailVerifyPostOkResponse):
                 user_info_from_callback = response.user
 
             return response
@@ -752,7 +752,7 @@ async def test_the_email_verify_api_with_valid_input_overriding_apis(driver_conf
 
             response = await temp(token, api_options, user_context)
 
-            if response.status == "OK":
+            if isinstance(response, EmailVerifyPostOkResponse):
                 user_info_from_callback = response.user
 
             return response
@@ -844,7 +844,7 @@ async def test_the_email_verify_api_with_valid_input_overriding_apis_throws_erro
 
             response = await temp(token, api_options, user_context)
 
-            if response.status == "OK":
+            if isinstance(response, EmailVerifyPostOkResponse):
                 user_info_from_callback = response.user
 
             raise BadInputError("verify exception")

--- a/tests/emailpassword/test_emailverify.py
+++ b/tests/emailpassword/test_emailverify.py
@@ -29,7 +29,8 @@ from supertokens_python.recipe.emailpassword.asyncio import (
     revoke_email_verification_token, unverify_email, verify_email_using_token)
 from supertokens_python.recipe.emailpassword.types import User
 from supertokens_python.recipe.emailverification.interfaces import (
-    APIInterface, APIOptions, EmailVerifyPostOkResponse)
+    APIInterface, APIOptions, EmailVerifyPostOkResponse,
+    VerifyEmailUsingTokenInvalidTokenErrorResult)
 from supertokens_python.recipe.emailverification.types import User as EVUser
 from supertokens_python.recipe.emailverification.utils import OverrideConfig
 from supertokens_python.recipe.session import SessionContainer
@@ -953,7 +954,7 @@ async def test_the_generate_token_api_with_valid_input_and_then_remove_token(dri
     if verify_token.token is None:
         raise Exception("Should never come here")
     response = await verify_email_using_token(verify_token.token)
-    assert response.status == "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR"
+    assert isinstance(response, VerifyEmailUsingTokenInvalidTokenErrorResult)
 
 
 @mark.asyncio


### PR DESCRIPTION
## Summary of change

- Modified EmailVerifyPostOkResponse and EmailVerifyPostInvalidTokenErrorResponse classes under recipe.emailvarification.interfaces.

- Modified EmailVerifyPostResponse class.
    
    This results in more readable code in recipe.emailverification.api.implementation. The code for email varification now looks like:
    
        response = await api_options.recipe_implementation.verify_email_using_token(token, user_context)
            if response.user:
                return EmailVerifyPostOkResponse(response.user)
            return EmailVerifyPostInvalidTokenErrorResponse()
    
- Added docstrings in EmailVerifyPostOkResponse, EmailVerifyPostInvalidTokenErrorResponse and email_verify_post method for email verification.

## Related issues

-   [Link to issue1 here](https://github.com/supertokens/supertokens-python/issues/75)

Signed-off-by: Girish Joshi <girish946@gmail.com>