### PR TITLE
fix: https://github.com/supertokens/supertokens-python/issues/90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ## [0.5.2] - 2022-03-17
-### Adds
+### Fixes
+- https://github.com/supertokens/supertokens-python/issues/90
 - Thirdpartypasswordless recipe + tests
+
+### Changed:
+- Added new function to BaseRequest class called `set_session_as_none` to set session object to None.
 
 ## [0.5.1] - 2022-03-02
 

--- a/supertokens_python/framework/django/django_request.py
+++ b/supertokens_python/framework/django/django_request.py
@@ -60,6 +60,9 @@ class DjangoRequest(BaseRequest):
     def set_session(self, session: SessionContainer):
         self.request.supertokens = session  # type: ignore
 
+    def set_session_as_none(self):
+        self.request.supertokens = None  # type: ignore
+
     def get_path(self) -> str:
         return self.request.path
 

--- a/supertokens_python/framework/fastapi/fastapi_request.py
+++ b/supertokens_python/framework/fastapi/fastapi_request.py
@@ -55,6 +55,9 @@ class FastApiRequest(BaseRequest):
     def set_session(self, session: SessionContainer):
         self.request.state.supertokens = session
 
+    def set_session_as_none(self):
+        self.request.state.supertokens = None
+
     def get_path(self) -> str:
         return self.request.url.path
 

--- a/supertokens_python/framework/flask/flask_middleware.py
+++ b/supertokens_python/framework/flask/flask_middleware.py
@@ -67,7 +67,7 @@ class Middleware:
         def _(response: Response):
             from flask import g
             response_ = FlaskResponse(response)
-            if hasattr(g, 'supertokens'):
+            if hasattr(g, 'supertokens') and g.supertokens is not None:
                 manage_cookies_post_response(g.supertokens, response_)
 
             return response_.response

--- a/supertokens_python/framework/flask/flask_request.py
+++ b/supertokens_python/framework/flask/flask_request.py
@@ -61,6 +61,10 @@ class FlaskRequest(BaseRequest):
         from flask import g
         g.supertokens = session
 
+    def set_session_as_none(self):
+        from flask import g
+        g.supertokens = None
+
     def get_path(self) -> str:
         if isinstance(self.request, dict):
             temp: str = self.request['PATH_INFO']

--- a/supertokens_python/framework/request.py
+++ b/supertokens_python/framework/request.py
@@ -60,5 +60,12 @@ class BaseRequest(ABC):
         pass
 
     @abstractmethod
+    def set_session_as_none(self):
+        """
+        This function is used to set the request's session variable to None.
+        See https://github.com/supertokens/supertokens-python/issues/90
+        """
+
+    @abstractmethod
     def get_path(self) -> str:
         pass

--- a/supertokens_python/recipe/session/framework/django/asyncio/__init__.py
+++ b/supertokens_python/recipe/session/framework/django/asyncio/__init__.py
@@ -40,6 +40,7 @@ def verify_session(anti_csrf_check: Union[bool, None] = None, session_required: 
                 if session is None:
                     if session_required:
                         raise Exception("Should never come here")
+                    baseRequest.set_session_as_none()
                 else:
                     baseRequest.set_session(session)
                 return await f(baseRequest.request, *args, **kwargs)

--- a/supertokens_python/recipe/session/framework/django/syncio/__init__.py
+++ b/supertokens_python/recipe/session/framework/django/syncio/__init__.py
@@ -41,6 +41,7 @@ def verify_session(anti_csrf_check: Union[bool, None] = None, session_required: 
                 if session is None:
                     if session_required:
                         raise Exception("Should never come here")
+                    baseRequest.set_session_as_none()
                 else:
                     baseRequest.set_session(session)
                 return f(baseRequest.request, *args, **kwargs)

--- a/supertokens_python/recipe/session/framework/fastapi/__init__.py
+++ b/supertokens_python/recipe/session/framework/fastapi/__init__.py
@@ -32,6 +32,7 @@ def verify_session(
         if session is None:
             if session_required:
                 raise Exception("Should never come here")
+            baseRequest.set_session_as_none()
         else:
             baseRequest.set_session(session)
         return baseRequest.get_session()

--- a/supertokens_python/recipe/session/framework/flask/__init__.py
+++ b/supertokens_python/recipe/session/framework/flask/__init__.py
@@ -40,6 +40,7 @@ def verify_session(anti_csrf_check: Union[bool, None] = None, session_required: 
             if session is None:
                 if session_required:
                     raise Exception("Should never come here")
+                baseRequest.set_session_as_none()
             else:
                 baseRequest.set_session(session)
             response = make_response(f(*args, **kwargs))

--- a/tests/Fastapi/test_fastapi.py
+++ b/tests/Fastapi/test_fastapi.py
@@ -11,25 +11,25 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import Union
-from supertokens_python.recipe.emailpassword.interfaces import \
-    APIInterface as EPAPIInterface
-from typing import Any, Dict
-from supertokens_python.recipe.session.interfaces import APIInterface
-from supertokens_python.recipe.session import SessionContainer
 import json
+from typing import Any, Dict, Union
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.requests import Request
 from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.framework.fastapi import Middleware
 from supertokens_python.recipe import emailpassword, session
+from supertokens_python.recipe.emailpassword.interfaces import \
+    APIInterface as EPAPIInterface
 from supertokens_python.recipe.emailpassword.interfaces import APIOptions
+from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.asyncio import (create_new_session,
                                                        get_session,
                                                        refresh_session)
+from supertokens_python.recipe.session.framework.fastapi import verify_session
+from supertokens_python.recipe.session.interfaces import APIInterface
 from tests.utils import (TEST_DRIVER_CONFIG_ACCESS_TOKEN_PATH,
                          TEST_DRIVER_CONFIG_COOKIE_DOMAIN,
                          TEST_DRIVER_CONFIG_COOKIE_SAME_SITE,
@@ -82,6 +82,12 @@ async def driver_config_client():
         session: Union[None, SessionContainer] = await get_session(request, True)
         if session is None:
             raise Exception("Should never come here")
+        return {'s': session.get_handle()}
+
+    @app.get('/handle-session-optional')
+    async def handle_get_optional(session: SessionContainer = Depends(verify_session(session_required=False))):  # type: ignore
+        if session is None:
+            return {'s': "empty session"}
         return {'s': session.get_handle()}
 
     @app.post('/logout')
@@ -449,3 +455,28 @@ async def test_custom_response(driver_config_client: TestClient):
     dict_response = json.loads(response.text)
     assert response.status_code == 203
     assert dict_response["custom"]
+
+
+@mark.asyncio
+async def test_optional_session(driver_config_client: TestClient):
+
+    init(
+        supertokens_config=SupertokensConfig('http://localhost:3567'),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="http://api.supertokens.io",
+            website_domain="http://supertokens.io",
+            api_base_path="/auth"
+        ),
+        framework='fastapi',
+        recipe_list=[session.init()]
+    )
+    start_st()
+
+    response = driver_config_client.get(
+        url='handle-session-optional',
+    )
+
+    dict_response = json.loads(response.text)
+    assert response.status_code == 200
+    assert dict_response["s"] == "empty session"


### PR DESCRIPTION
## Summary of change

Fixes issue where we were not setting the supertokens object to `None` in case of optional session verification

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/90

## Test Plan

Added new tests for all supported frameworks with optional session verification API

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
