### PR TITLE
docs: Addeed docstrings to the emailpassword recipe interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Adds
+- docstrings to the recipe interfaces for `emailpassword`
 
 ## [0.5.2] - 2022-03-17
 ### Fixes

--- a/supertokens_python/recipe/emailpassword/api/implementation.py
+++ b/supertokens_python/recipe/emailpassword/api/implementation.py
@@ -35,12 +35,64 @@ if TYPE_CHECKING:
 
 
 class APIImplementation(APIInterface):
+    """
+    The default implementation for `supertokens_python.recipe.emailpassword` recipe APIs.
+
+    ...
+
+    Attributes
+    ----------
+    querier: `supertokens_python.querier.Querier`
+        API required to query `supertokens-core` and collect the result.
+    """
+
     async def email_exists_get(self, email: str, api_options: APIOptions, user_context: Dict[str, Any]) -> EmailExistsGetResponse:
+        """
+        async method to process the email exists get request.
+
+        ...
+
+        Args:
+        -----
+
+        email: `str`
+            email to be checked if it exists
+
+        api_options: `supertokens_python.recipe.emailpassword.interfaces.APIOptions`
+            APIOptions for recipe implementation.
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.EmailExistsGetResponse`
+        """
+
         user = await api_options.recipe_implementation.get_user_by_email(email, user_context)
         return EmailExistsGetOkResponse(user is not None)
 
     async def generate_password_reset_token_post(self, form_fields: List[FormField],
                                                  api_options: APIOptions, user_context: Dict[str, Any]) -> GeneratePasswordResetTokenPostResponse:
+        """
+        async method to process generate password reset token post request.
+
+        ...
+
+        Args:
+        -----
+
+        form_field: `List`[`FormField`]
+
+        api_options: `supertokens_python.recipe.emailpassword.interfaces.APIOptions`
+            APIOptions for recipe implementation.
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.GeneratePasswordResetTokenPostResponse`
+        """
+
         emailFormField = find_first_occurrence_in_list(
             lambda x: x.id == FORM_FIELD_EMAIL_ID, form_fields)
         if emailFormField is None:
@@ -70,6 +122,29 @@ class APIImplementation(APIInterface):
 
     async def password_reset_post(self, form_fields: List[FormField], token: str,
                                   api_options: APIOptions, user_context: Dict[str, Any]) -> PasswordResetPostResponse:
+        """
+        async method to process reset password request.
+
+        ...
+
+        Args:
+        -----
+
+        form_field: `List`[`FormField`]
+
+        token: `str`
+            access token for the password reset request.
+
+        api_options: `supertokens_python.recipe.emailpassword.interfaces.APIOptions`
+            APIOptions for recipe implementation.
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.PasswordResetPostResponse`
+        """
+
         new_password_for_field = find_first_occurrence_in_list(
             lambda x: x.id == FORM_FIELD_PASSWORD_ID, form_fields)
         if new_password_for_field is None:
@@ -82,6 +157,26 @@ class APIImplementation(APIInterface):
         return PasswordResetPostInvalidTokenResponse()
 
     async def sign_in_post(self, form_fields: List[FormField], api_options: APIOptions, user_context: Dict[str, Any]) -> SignInPostResponse:
+        """
+        async method to process sign in post request.
+
+        ...
+
+        Args:
+        -----
+
+        form_field: `List`[`FormField`]
+
+        api_options: `supertokens_python.recipe.emailpassword.interfaces.APIOptions`
+            APIOptions for recipe implementation.
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.SignInPostResponse`
+        """
+
         password_form_field = find_first_occurrence_in_list(
             lambda x: x.id == FORM_FIELD_PASSWORD_ID, form_fields)
         if password_form_field is None:
@@ -104,6 +199,26 @@ class APIImplementation(APIInterface):
         return SignInPostOkResponse(user, session)
 
     async def sign_up_post(self, form_fields: List[FormField], api_options: APIOptions, user_context: Dict[str, Any]) -> SignUpPostResponse:
+        """
+        async method to process sign up post request.
+
+        ...
+
+        Args:
+        -----
+
+        form_field: `List`[`FormField`]
+
+        api_options: `supertokens_python.recipe.emailpassword.interfaces.APIOptions`
+            APIOptions for recipe implementation.
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.SignUpPostResponse`
+        """
+
         password_form_field = find_first_occurrence_in_list(
             lambda x: x.id == FORM_FIELD_PASSWORD_ID, form_fields)
         if password_form_field is None:

--- a/supertokens_python/recipe/emailpassword/exceptions.py
+++ b/supertokens_python/recipe/emailpassword/exceptions.py
@@ -30,6 +30,19 @@ class SuperTokensEmailPasswordError(SuperTokensError):
 
 
 class FieldError(SuperTokensEmailPasswordError):
+    """
+    Error when the Form Fields contain invalid values.
+
+    ...
+
+    Attributes
+    ----------
+    msg: `str`
+        error message
+
+    form_fields: `List`[`supertokens_python.recipe.emailpassword.types.ErrorFormField`]
+    """
+
     def __init__(self, msg: str, form_fields: List[ErrorFormField]):
         super().__init__(msg)
         self.form_fields = form_fields

--- a/supertokens_python/recipe/emailpassword/interfaces.py
+++ b/supertokens_python/recipe/emailpassword/interfaces.py
@@ -14,7 +14,7 @@
 
 """
 In this module, classes with suffix `Result` are responsible for holding the result of the operations/calls to the supertokens-core.
-The classes with suffix `Response` are responsible for holding the responses to be sent to incomming API requests.
+The classes with suffix `Response` are responsible for holding the responses to be sent to incoming API requests.
 """
 
 

--- a/supertokens_python/recipe/emailpassword/interfaces.py
+++ b/supertokens_python/recipe/emailpassword/interfaces.py
@@ -11,6 +11,13 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+"""
+In this module, classes with suffix `Result` are responsible for holding the result of the operations/calls to the supertokens-core.
+The classes with suffix `Response` are responsible for holding the responses to be sent to incomming API requests.
+"""
+
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -586,7 +593,7 @@ class EmailVerifyPostResponse(ABC):
         Flag to indicate if the operation completed successfully.
 
     is_email_verification_invalid_token_error: boolean
-        Flag to indicate if the email is already registered.
+        Flag to indicate if the email verification token is invalid.
 
     user:
         Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
@@ -607,6 +614,27 @@ class EmailVerifyPostResponse(ABC):
 
 
 class EmailVerifyPostOkResponse(EmailVerifyPostResponse):
+    """
+    class for holding the response to be sent for a email verify post request on a successful verification.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        This will hold `OK` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_verification_invalid_token_error: boolean
+        Flag to indicate if the email verification token is invalid.
+
+    user:
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+    """
+
     def __init__(self, user: User):
         super().__init__('OK', user)
         self.is_ok = True
@@ -625,6 +653,24 @@ class EmailVerifyPostOkResponse(EmailVerifyPostResponse):
 
 
 class EmailVerifyPostInvalidTokenErrorResponse(EmailVerifyPostResponse):
+    """
+    class for holding the response to be sent for a email verify post request on a verification failure.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        This will hold `EMAIL_VERIFICATION_INVALID_TOKEN_ERROR` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_verification_invalid_token_error: boolean
+        Flag to indicate if the email verification token is invalid.
+    """
+
     def __init__(self):
         super().__init__('EMAIL_VERIFICATION_INVALID_TOKEN_ERROR', None)
         self.is_ok = False
@@ -632,6 +678,21 @@ class EmailVerifyPostInvalidTokenErrorResponse(EmailVerifyPostResponse):
 
 
 class IsEmailVerifiedGetResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a is email verified get request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        The possible values for this could be `OK`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+    """
+
     def __init__(self, status: Literal['OK']):
         self.status = status
         self.is_ok = False
@@ -643,6 +704,24 @@ class IsEmailVerifiedGetResponse(ABC):
 
 
 class IsEmailVerifiedGetOkResponse(IsEmailVerifiedGetResponse):
+    """
+    class for holding the response to be sent for a successful is email verified get request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        This will hold `OK`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_verified: boolean
+        Flag to indicate if the email is verified.
+    """
+
     def __init__(self, is_verified: bool):
         super().__init__('OK')
         self.is_verified = is_verified
@@ -656,6 +735,24 @@ class IsEmailVerifiedGetOkResponse(IsEmailVerifiedGetResponse):
 
 
 class GenerateEmailVerifyTokenPostResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a generate email verify toekn post request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        The possible values for this could be `OK` or `EMAIL_ALREADY_VERIFIED_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_verified_error: boolean
+        Flag to indicate if the email is already verified.
+    """
+
     def __init__(self, status: Literal['OK', 'EMAIL_ALREADY_VERIFIED_ERROR']):
         self.status = status
         self.is_ok = False
@@ -669,6 +766,24 @@ class GenerateEmailVerifyTokenPostResponse(ABC):
 
 class GenerateEmailVerifyTokenPostOkResponse(
         GenerateEmailVerifyTokenPostResponse):
+    """
+    class for holding the response to be sent for a successful generate email verify toekn post request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        This will hold `OK`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_verified_error: boolean
+        Flag to indicate if the email is already verified.
+    """
+
     def __init__(self):
         super().__init__('OK')
         self.is_ok = True
@@ -677,6 +792,24 @@ class GenerateEmailVerifyTokenPostOkResponse(
 
 class GenerateEmailVerifyTokenPostEmailAlreadyVerifiedErrorResponse(
         GenerateEmailVerifyTokenPostResponse):
+    """
+    class for holding the response to be sent for a failed generate email verify toekn post request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        This will hold `EMAIL_ALREADY_VERIFIED_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_verified_error: boolean
+        Flag to indicate if the email is already verified.
+    """
+
     def __init__(self):
         super().__init__('EMAIL_ALREADY_VERIFIED_ERROR')
         self.is_ok = False
@@ -684,6 +817,21 @@ class GenerateEmailVerifyTokenPostEmailAlreadyVerifiedErrorResponse(
 
 
 class EmailExistsGetResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a email exists get request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        The possible values for this could be `OK`.
+
+    exists: boolean
+        Flag to indicate if the email exists.
+    """
+
     def __init__(self, status: Literal['OK'], exists: bool):
         self.status = status
         self.exists = exists
@@ -696,11 +844,38 @@ class EmailExistsGetResponse(ABC):
 
 
 class EmailExistsGetOkResponse(EmailExistsGetResponse):
+    """
+    class for holding the response to be sent for a email exists get request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        This holds `OK`.
+
+    exists: boolean
+        Flag to indicate if the email exists.
+    """
+
     def __init__(self, exists: bool):
         super().__init__('OK', exists)
 
 
 class GeneratePasswordResetTokenPostResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a generate password reset token post request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        The possible values for this could be `OK`.
+    """
+
     def __init__(self, status: Literal['OK']):
         self.status = status
 
@@ -712,11 +887,38 @@ class GeneratePasswordResetTokenPostResponse(ABC):
 
 class GeneratePasswordResetTokenPostOkResponse(
         GeneratePasswordResetTokenPostResponse):
+    """
+    class for holding the response to be sent for a successful generate password reset token post request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the generate password reset token post request.
+        This will hold `OK`.
+    """
+
     def __init__(self):
         super().__init__('OK')
 
 
 class PasswordResetPostResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a password reset post request.
+
+    ...
+
+    Attributes
+    ----------
+    user_id: str
+        user_id for which password needs to be reset.
+
+    status: str
+        Status string for result of the password reset post request.
+        The possible values for this could be `OK` or `RESET_PASSWORD_INVALID_TOKEN_ERROR`.
+    """
+
     def __init__(self, status: Literal['OK',
                  'RESET_PASSWORD_INVALID_TOKEN_ERROR'], user_id: Union[str, None] = None):
         self.user_id: Union[str, None] = user_id
@@ -730,16 +932,74 @@ class PasswordResetPostResponse(ABC):
 
 
 class PasswordResetPostOkResponse(PasswordResetPostResponse):
+    """
+    class for holding the response to be sent for a successful password reset post request.
+
+    ...
+
+    Attributes
+    ----------
+    user_id: str
+        user_id for which password needs to be reset.
+
+    status: str
+        Status string for result of the password reset post request.
+        This will hold `OK`.
+    """
+
     def __init__(self, user_id: Union[str, None]):
         super().__init__('OK', user_id)
 
 
 class PasswordResetPostInvalidTokenResponse(PasswordResetPostResponse):
+    """
+    class for holding the response to be sent for a failed password reset post request.
+
+    ...
+
+    Attributes
+    ----------
+    user_id: str
+        user_id for which password needs to be reset.
+
+    status: str
+        Status string for result of the password reset post request.
+        This will hold `RESET_PASSWORD_INVALID_TOKEN_ERROR`.
+    """
+
     def __init__(self):
         super().__init__('RESET_PASSWORD_INVALID_TOKEN_ERROR')
 
 
 class SignInPostResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a signin request.
+
+    ...
+
+    Attributes
+    ----------
+
+    status: str
+        Status string for result of the signin request.
+        The possible values for this could be `OK` or `WRONG_CREDENTIALS_ERROR`.
+
+    type: str
+        This holds `emailpassword`
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_wrong_credentials_error: boolean
+        Flag to indicate if the provided credentials are invalid.
+
+    user: `supertokens_python.recipe.emailpassword.types.User`
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+
+    session: `supertokens_python.recipe.session.SessionContainer`
+        Object of `supertokens_python.recipe.session.SessionContainer` to hold a session object.
+    """
+
     def __init__(
             self, status: Literal['OK', 'WRONG_CREDENTIALS_ERROR'],
             user: Union[User, None] = None,
@@ -768,18 +1028,84 @@ class SignInPostResponse(ABC):
 
 
 class SignInPostOkResponse(SignInPostResponse):
+    """
+    class for holding the response to be sent for a successful signin request.
+
+    ...
+
+    Attributes
+    ----------
+
+    status: str
+        Status string for result of the signin post request.
+        This will hold `OK`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    user: `supertokens_python.recipe.emailpassword.types.User`
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+
+    session: `supertokens_python.recipe.session.SessionContainer`
+        Object of `supertokens_python.recipe.session.SessionContainer` to hold a session object.
+    """
+
     def __init__(self, user: User, session: SessionContainer):
         super().__init__('OK', user, session)
         self.is_ok = True
 
 
 class SignInPostWrongCredentialsErrorResponse(SignInPostResponse):
+    """
+    class for holding the response to be sent for a failed signin request.
+
+    ...
+
+    Attributes
+    ----------
+
+    status: str
+        Status string for result of the signin post request.
+        This will hold `WRONG_CREDENTIALS_ERROR`.
+
+    is_wrong_credentials_error: boolean
+        Flag to indicate if the credentials are invalid
+    """
+
     def __init__(self):
         super().__init__('WRONG_CREDENTIALS_ERROR')
         self.is_wrong_credentials_error = True
 
 
 class SignUpPostResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a signup request.
+
+    ...
+
+    Attributes
+    ----------
+
+    status: str
+        Status string for result of the signup request.
+        The possible values for this could be `OK` or `EMAIL_ALREADY_EXISTS_ERROR`.
+
+    type: str
+        This holds `emailpassword`
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email already exists.
+
+    user: `supertokens_python.recipe.emailpassword.types.User`
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+
+    session: `supertokens_python.recipe.session.SessionContainer`
+        Object of `supertokens_python.recipe.session.SessionContainer` to hold a session object.
+    """
+
     def __init__(
             self, status: Literal['OK', 'EMAIL_ALREADY_EXISTS_ERROR'],
             user: Union[User, None] = None,
@@ -808,18 +1134,80 @@ class SignUpPostResponse(ABC):
 
 
 class SignUpPostOkResponse(SignUpPostResponse):
+    """
+    class for holding the response to be sent for a successful signup request.
+
+    ...
+
+    Attributes
+    ----------
+
+    status: str
+        Status string for result of the password signup request.
+        This will hold `OK`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    user: `supertokens_python.recipe.emailpassword.types.User`
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+
+    session: `supertokens_python.recipe.session.SessionContainer`
+        Object of `supertokens_python.recipe.session.SessionContainer` to hold a session object.
+    """
+
     def __init__(self, user: User, session: SessionContainer):
         super().__init__('OK', user, session)
         self.is_ok = True
 
 
 class SignUpPostEmailAlreadyExistsErrorResponse(SignUpPostResponse):
+    """
+    class for holding the response to be sent for a failed signup request.
+
+    ...
+
+    Attributes
+    ----------
+
+    status: str
+        Status string for result of the password signup request.
+        This will hold `EMAIL_ALREADY_EXISTS_ERROR`.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email already exists.
+    """
+
     def __init__(self):
         super().__init__('EMAIL_ALREADY_EXISTS_ERROR')
         self.is_email_already_exists_error = True
 
 
 class APIInterface:
+    """
+    class to define APIInterface for emailpassword recipe
+
+    ...
+
+    Attributes
+    ----------
+
+    disable_email_exists_get: boolean
+        config flag to disable `disable_email_exists_get`
+
+    disable_generate_password_reset_token_post: boolean
+        config flag to disable `disable_generate_password_reset_token_post`
+
+    disable_password_reset_post: boolean
+        config flag to disable `disable_password_reset_post`
+
+    disable_sign_in_post: boolean
+        config flag to disable `disable_sign_in_post`
+
+    disable_sign_up_post: boolean
+        config flag to disable `disable_sign_up_post`
+    """
+
     def __init__(self):
         self.disable_email_exists_get = False
         self.disable_generate_password_reset_token_post = False

--- a/supertokens_python/recipe/emailpassword/interfaces.py
+++ b/supertokens_python/recipe/emailpassword/interfaces.py
@@ -17,10 +17,10 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 from xmlrpc.client import boolean
 
+from typing_extensions import Literal
+
 from ..emailverification.interfaces import \
     RecipeInterface as EmailVerificationRecipeInterface
-
-from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from supertokens_python.framework import BaseRequest, BaseResponse
@@ -31,6 +31,28 @@ if TYPE_CHECKING:
 
 
 class SignUpResult(ABC):
+    """
+    Abstract class for holding the result of signup call.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the signup call to the supertokens-core.
+        The possible values for this could be `OK` or `EMAIL_ALREADY_EXISTS_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+
+    user:
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+        This will be `None` in case of error.
+    """
+
     def __init__(
             self, status: Literal['OK', 'EMAIL_ALREADY_EXISTS_ERROR'], user: Union[User, None]):
         self.status = status
@@ -40,6 +62,27 @@ class SignUpResult(ABC):
 
 
 class SignUpOkResult(SignUpResult):
+    """
+    Class to hold the result of a successful signup call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the signup call to the supertokens-core.
+        The possible values for this could be `OK` or `EMAIL_ALREADY_EXISTS_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+
+    user:
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+    """
+
     def __init__(self, user: User):
         super().__init__('OK', user)
         self.is_ok = True
@@ -47,6 +90,24 @@ class SignUpOkResult(SignUpResult):
 
 
 class SignUpEmailAlreadyExistsErrorResult(SignUpResult):
+    """
+    Class to hold the result of a failed signup call to supertokens-core where the email is already registered.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the signup call to the supertokens-core.
+        The possible values for this could be `OK` or `EMAIL_ALREADY_EXISTS_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+    """
+
     def __init__(self):
         super().__init__('EMAIL_ALREADY_EXISTS_ERROR', None)
         self.is_ok = False
@@ -54,6 +115,28 @@ class SignUpEmailAlreadyExistsErrorResult(SignUpResult):
 
 
 class SignInResult(ABC):
+    """
+    Class to hold the result of a Signin call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the Signin call to supertokens-core.
+        The possible values for this could be `OK` or `WRONG_CREDENTIALS_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_wrong_credentials_error: boolean
+        Flag to indicate if the provided credentials are incorrect.
+
+    user:
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+        This will be `None` in case of error.
+    """
+
     def __init__(
             self, status: Literal['OK', 'WRONG_CREDENTIALS_ERROR'], user: Union[User, None]):
         self.status: Literal['OK', 'WRONG_CREDENTIALS_ERROR'] = status
@@ -63,6 +146,27 @@ class SignInResult(ABC):
 
 
 class SignInOkResult(SignInResult):
+    """
+    Class to hold the successful result of a Signin call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the Signin call to supertokens-core.
+        This will hold `OK` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_wrong_credentials_error: boolean
+        Flag to indicate if the provided credentials are incorrect.
+
+    user:
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+    """
+
     def __init__(self, user: User):
         super().__init__('OK', user)
         self.is_ok = True
@@ -70,6 +174,24 @@ class SignInOkResult(SignInResult):
 
 
 class SignInWrongCredentialsErrorResult(SignInResult):
+    """
+    Class to hold the result of a failed Signin call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the Signin call to supertokens-core.
+        This will hold `WRONG_CREDENTIALS_ERROR` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_wrong_credentials_error: boolean
+        Flag to indicate if the provided credentials are incorrect.
+    """
+
     def __init__(self):
         super().__init__('WRONG_CREDENTIALS_ERROR', None)
         self.is_ok = False
@@ -77,6 +199,27 @@ class SignInWrongCredentialsErrorResult(SignInResult):
 
 
 class CreateResetPasswordResult(ABC):
+    """
+    Class to hold the result of a create reset password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the create reset password call to supertokens-core.
+        The possible values for this could be `OK` or `UNKNOWN_USER_ID_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the provided user id is invalid.
+
+    token: str
+        Token to reset password in case of successful create reset user password call to the supertokens-core.
+    """
+
     def __init__(
             self, status: Literal['OK', 'UNKNOWN_USER_ID_ERROR'], token: Union[str, None]):
         self.status = status
@@ -86,6 +229,27 @@ class CreateResetPasswordResult(ABC):
 
 
 class CreateResetPasswordOkResult(CreateResetPasswordResult):
+    """
+    Class to hold the result of a successful create reset password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the create reset password call to supertokens-core.
+        This will hold `OK` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the provided user id is invalid.
+
+    token: str
+        Token to reset password in case of successful create reset user password call to the supertokens-core.
+    """
+
     def __init__(self, token: str):
         super().__init__('OK', token)
         self.is_ok = True
@@ -93,6 +257,24 @@ class CreateResetPasswordOkResult(CreateResetPasswordResult):
 
 
 class CreateResetPasswordWrongUserIdErrorResult(CreateResetPasswordResult):
+    """
+    Class to hold the result of a failed create reset password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the create reset password call to supertokens-core.
+        This will hold `UNKNOWN_USER_ID_ERROR` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the provided user id is invalid.
+    """
+
     def __init__(self):
         super().__init__('UNKNOWN_USER_ID_ERROR', None)
         self.is_ok = False
@@ -100,6 +282,27 @@ class CreateResetPasswordWrongUserIdErrorResult(CreateResetPasswordResult):
 
 
 class ResetPasswordUsingTokenResult(ABC):
+    """
+    Class to hold the result of a reset password using token call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the reset password using token call to supertokens-core.
+        The possible values for this could be `OK` or `RESET_PASSWORD_INVALID_TOKEN_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_reset_password_invalid_token_error: boolean
+        Flag to indicate if the reset password token is invalid.
+
+    user_id: str
+        user-id for which reset password using token was called.
+    """
+
     def __init__(self, status: Literal['OK',
                  'RESET_PASSWORD_INVALID_TOKEN_ERROR'], user_id: Union[None, str] = None):
         self.status: Literal['OK',
@@ -110,6 +313,27 @@ class ResetPasswordUsingTokenResult(ABC):
 
 
 class ResetPasswordUsingTokenOkResult(ResetPasswordUsingTokenResult):
+    """
+    Class to hold the result of a successful reset password using token call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the successful reset password using token call to supertokens-core.
+        This will hold `OK` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_reset_password_invalid_token_error: boolean
+        Flag to indicate if the reset password token is invalid.
+
+    user_id: str
+        user-id for which reset password using token was called.
+    """
+
     def __init__(self, user_id: Union[None, str]):
         super().__init__('OK', user_id)
         self.is_ok = True
@@ -118,6 +342,27 @@ class ResetPasswordUsingTokenOkResult(ResetPasswordUsingTokenResult):
 
 class ResetPasswordUsingTokenWrongUserIdErrorResult(
         ResetPasswordUsingTokenResult):
+    """
+    Class to hold the result of a successful reset password using token call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the failed reset password using token call to supertokens-core.
+        This will hold `RESET_PASSWORD_INVALID_TOKEN_ERROR` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_reset_password_invalid_token_error: boolean
+        Flag to indicate if the reset password token is invalid.
+
+    user_id: str
+        user-id for which reset password using token was called.
+    """
+
     def __init__(self):
         super().__init__('RESET_PASSWORD_INVALID_TOKEN_ERROR')
         self.is_ok = False
@@ -125,6 +370,27 @@ class ResetPasswordUsingTokenWrongUserIdErrorResult(
 
 
 class UpdateEmailOrPasswordResult(ABC):
+    """
+    Class to hold the result of a update email or password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the update email or password call to the supertokens-core.
+        The possible values for this could be `OK`, `UNKNOWN_USER_ID_ERROR` or `EMAIL_ALREADY_EXISTS_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the user id used for makeing update email or password call is invalid.
+    """
+
     def __init__(
             self, status: Literal['OK', 'UNKNOWN_USER_ID_ERROR', 'EMAIL_ALREADY_EXISTS_ERROR']):
         self.status = status
@@ -134,6 +400,27 @@ class UpdateEmailOrPasswordResult(ABC):
 
 
 class UpdateEmailOrPasswordOkResult(UpdateEmailOrPasswordResult):
+    """
+    Class to hold the result of successful update email or password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the update email or password call to the supertokens-core.
+        This will hold `Ok` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the user id used for makeing update email or password call is invalid.
+    """
+
     def __init__(self):
         super().__init__('OK')
         self.is_ok = True
@@ -143,6 +430,27 @@ class UpdateEmailOrPasswordOkResult(UpdateEmailOrPasswordResult):
 
 class UpdateEmailOrPasswordEmailAlreadyExistsErrorResult(
         UpdateEmailOrPasswordResult):
+    """
+    Class to hold the result of failed update email or password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the update email or password call to the supertokens-core.
+        This will hold `EMAIL_ALREADY_EXISTS_ERROR` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the user id used for makeing update email or password call is invalid.
+    """
+
     def __init__(self):
         super().__init__('EMAIL_ALREADY_EXISTS_ERROR')
         self.is_ok = False
@@ -152,6 +460,27 @@ class UpdateEmailOrPasswordEmailAlreadyExistsErrorResult(
 
 class UpdateEmailOrPasswordUnknownUserIdErrorResult(
         UpdateEmailOrPasswordResult):
+    """
+    Class to hold the result of failed update email or password call to supertokens-core.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the update email or password call to the supertokens-core.
+        This will hold `UNKNOWN_USER_ID_ERROR` in the instance of this class.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_already_exists_error: boolean
+        Flag to indicate if the email is already registered.
+
+    is_unknown_user_id_error: boolean
+        Flag to indicate if the user id used for makeing update email or password call is invalid.
+    """
+
     def __init__(self):
         super().__init__('UNKNOWN_USER_ID_ERROR')
         self.is_ok = False
@@ -160,6 +489,11 @@ class UpdateEmailOrPasswordUnknownUserIdErrorResult(
 
 
 class RecipeInterface(ABC):
+    """
+    Recipe interface for `supertokens_python.recipe.emailpassword` recipe.
+    #TODO: add more details.
+    """
+
     def __init__(self):
         pass
 
@@ -195,6 +529,36 @@ class RecipeInterface(ABC):
 
 
 class APIOptions:
+    """
+    Class to configure the `supertokens_python.recipe.emailpassword` recipe.
+    This is used to configure the outword facing APIs used in the middleware of the target framewor (`flask`, `django`, `fastapi`).
+
+    ...
+
+    Attributes
+    ----------
+    request: `supertokens_python.framework.BaseRequest`
+        Wrapper for the wsgi request.
+        #TODO: fix the docstring for `supertokens_python.framework.BaseRequest`
+
+    response: `supertokens_python.framework.BaseResponse`
+        Wrapper for the wsgi response
+        #TODO: fix the docstring for `supertokens_python.framework.BaseResponse`
+
+    recipe_id: str
+        name/id for the recipe
+
+    config: `supertokens_python.recipe.emailpassword.utils.EmailPasswordConfig`
+        configuration for the emailpassword recipe
+
+    recipe_implementation: `supertokens_python.recipe.emailpassword.interfcaes.RecipeInterface`
+        Object of `supertokens_python.recipe.emailpassword.interfcaes.RecipeInterface`,
+        modify this object for the customization.
+
+    email_verification_recipe_implementation: `supertokens_python.recipe.emailverification.EmailVerificationRecipeInterface`
+        Object of `supertokens_python.recipe.emailpassword.interfcaes.RecipeInterface`, modify this object for customization.
+    """
+
     def __init__(self, request: BaseRequest, response: BaseResponse, recipe_id: str,
                  config: EmailPasswordConfig, recipe_implementation: RecipeInterface,
                  email_verification_recipe_implementation: EmailVerificationRecipeInterface):
@@ -207,6 +571,28 @@ class APIOptions:
 
 
 class EmailVerifyPostResponse(ABC):
+    """
+    Abstract class for holding the response to be sent for a email verify post request.
+
+    ...
+
+    Attributes
+    ----------
+    status: str
+        Status string for result of the email verify post request.
+        The possible values for this could be `OK` or `EMAIL_VERIFICATION_INVALID_TOKEN_ERROR`.
+
+    is_ok: boolean
+        Flag to indicate if the operation completed successfully.
+
+    is_email_verification_invalid_token_error: boolean
+        Flag to indicate if the email is already registered.
+
+    user:
+        Object of `supertokens_python.recipe.emailpassword.types.User` to hold the user details.
+        This will be `None` in case of error.
+    """
+
     def __init__(
             self, status: Literal['OK', 'EMAIL_VERIFICATION_INVALID_TOKEN_ERROR'], user: Union[User, None]):
         self.status = status

--- a/supertokens_python/recipe/emailpassword/recipe_implementation.py
+++ b/supertokens_python/recipe/emailpassword/recipe_implementation.py
@@ -37,11 +37,39 @@ if TYPE_CHECKING:
 
 
 class RecipeImplementation(RecipeInterface):
+    """
+    The default implementation for `supertokens_python.recipe.emailpassword` recipe.
+
+    ...
+
+    Attributes
+    ----------
+    querier: `supertokens_python.querier.Querier`
+        API required to query `supertokens-core` and collect the result.
+    """
+
     def __init__(self, querier: Querier):
         super().__init__()
         self.querier = querier
 
     async def get_user_by_id(self, user_id: str, user_context: Dict[str, Any]) -> Union[User, None]:
+        """
+        async method to retrive user details from the user-id.
+
+        ...
+
+        Args:
+        -----
+        user_id: `str`
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        Union[`supertokens_python.recipe.emailpassword.types.User`, `None`]
+
+        """
+
         params = {
             'userId': user_id
         }
@@ -52,6 +80,23 @@ class RecipeImplementation(RecipeInterface):
         return None
 
     async def get_user_by_email(self, email: str, user_context: Dict[str, Any]) -> Union[User, None]:
+        """
+        async method to retrive user details from the email.
+
+        ...
+
+        Args:
+        -----
+        email_id: `str`
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        Union[`supertokens_python.recipe.emailpassword.types.User`, `None`]
+
+        """
+
         params = {
             'email': email
         }
@@ -62,6 +107,22 @@ class RecipeImplementation(RecipeInterface):
         return None
 
     async def create_reset_password_token(self, user_id: str, user_context: Dict[str, Any]) -> CreateResetPasswordResult:
+        """
+        async method to create a reset password token.
+
+        ...
+
+        Args:
+        -----
+        user_id: `str`
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.CreateResetPasswordResult`
+        """
+
         data = {
             'userId': user_id
         }
@@ -73,6 +134,24 @@ class RecipeImplementation(RecipeInterface):
         return CreateResetPasswordWrongUserIdErrorResult()
 
     async def reset_password_using_token(self, token: str, new_password: str, user_context: Dict[str, Any]) -> ResetPasswordUsingTokenResult:
+        """
+        async method to  reset password using token.
+
+        ...
+
+        Args:
+        -----
+        token: `str`
+
+        new_password: `str`
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.ResetPasswordUsingTokenResult`
+        """
+
         data = {
             'method': 'token',
             'token': token,
@@ -88,6 +167,24 @@ class RecipeImplementation(RecipeInterface):
         return ResetPasswordUsingTokenOkResult(user_id)
 
     async def sign_in(self, email: str, password: str, user_context: Dict[str, Any]) -> SignInResult:
+        """
+        async method to Sign in using email and password.
+
+        ...
+
+        Args:
+        -----
+        email: `str`
+
+        password: `str`
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.SignInResult`
+        """
+
         data = {
             'password': password,
             'email': email
@@ -99,6 +196,24 @@ class RecipeImplementation(RecipeInterface):
         return SignInWrongCredentialsErrorResult()
 
     async def sign_up(self, email: str, password: str, user_context: Dict[str, Any]) -> SignUpResult:
+        """
+        async method to Sign up using email and password.
+
+        ...
+
+        Args:
+        -----
+        email: `str`
+
+        password: `str`
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.SignUpResult`
+        """
+
         data = {
             'password': password,
             'email': email
@@ -111,6 +226,26 @@ class RecipeImplementation(RecipeInterface):
 
     async def update_email_or_password(self, user_id: str, email: Union[str, None],
                                        password: Union[str, None], user_context: Dict[str, Any]) -> UpdateEmailOrPasswordResult:
+        """
+        async method to update the email or password.
+
+        ...
+
+        Args:
+        -----
+        user_id: `str`
+
+        email: `Union`[`str`, `None`]
+
+        password: `Union`[`str`, `None`]
+
+        user_context: `Dict`[`str`, `Any`]
+
+        Returns:
+        --------
+        `supertokens_python.recipe.emailpassword.interfaces.SignUpResult`
+        """
+
         data = {
             'userId': user_id
         }

--- a/supertokens_python/recipe/emailpassword/recipe_implementation.py
+++ b/supertokens_python/recipe/emailpassword/recipe_implementation.py
@@ -243,7 +243,7 @@ class RecipeImplementation(RecipeInterface):
 
         Returns:
         --------
-        `supertokens_python.recipe.emailpassword.interfaces.SignUpResult`
+        `supertokens_python.recipe.emailpassword.interfaces.UpdateEmailOrPasswordResult`
         """
 
         data = {

--- a/supertokens_python/recipe/emailpassword/types.py
+++ b/supertokens_python/recipe/emailpassword/types.py
@@ -15,6 +15,23 @@ from typing import Awaitable, Callable, List, Union
 
 
 class User:
+    """
+    Class to hold the User details.
+
+    ...
+
+    Attributes
+    ----------
+    user_id: `str`
+        user id for the given user.
+
+    email: `str`
+        email-id for the user.
+
+    time_joined: `int`
+        The time when user joined/signed up.
+    """
+
     def __init__(self, user_id: str, email: str, time_joined: int):
         self.user_id: str = user_id
         self.email: str = email
@@ -23,6 +40,23 @@ class User:
 
 
 class UsersResponse:
+    """
+    Class to hold the User list with pagination response.
+
+    ...
+
+    Attributes
+    ----------
+    users: `List`[`User`]
+        List of the users.
+
+    next_pagination_token: `Union`[`str`, `None`]
+        next pagination token
+
+    time_joined: `int`
+        The time when user joined/signed up.
+    """
+
     def __init__(self, users: List[User],
                  next_pagination_token: Union[str, None]):
         self.users = users
@@ -30,18 +64,63 @@ class UsersResponse:
 
 
 class ErrorFormField:
+    """
+    Class to hold the Form Field with error
+
+    ...
+
+    Attributes
+    ----------
+    id: `str`
+        Field id.
+
+    error: `str`
+        error message.
+    """
+
     def __init__(self, id: str, error: str):  # pylint: disable=redefined-builtin
         self.id = id
         self.error = error
 
 
 class FormField:
+    """
+    Class to hold the Form Field
+
+    ...
+
+    Attributes
+    ----------
+    id: `str`
+        Field id.
+
+    value: `str`
+        Field value.
+    """
+
     def __init__(self, id: str, value: str):  # pylint: disable=redefined-builtin
         self.id: str = id
         self.value: str = value
 
 
 class InputFormField:
+    """
+    Class to hold the Input Form Field
+
+    ...
+
+    Attributes
+    ----------
+    id: `str`
+        Field id.
+
+    validate: `Union`[`Callable`[[`str`], `Awaitable`[`Union`[`str`, `None`]]], `None`]
+        Validation coroutine
+
+    optional: `Union`[`bool`, `None`]
+        If the input form field is optional
+    """
+
     def __init__(self, id: str, validate: Union[Callable[[  # pylint: disable=redefined-builtin
                  str], Awaitable[Union[str, None]]], None] = None, optional: Union[bool, None] = None):
         self.id = id
@@ -50,6 +129,23 @@ class InputFormField:
 
 
 class NormalisedFormField:
+    """
+    Class to hold the Normalised Form Field
+
+    ...
+
+    Attributes
+    ----------
+    id: `str`
+        Field id.
+
+    validate: `Union`[`Callable`[[`str`], `Awaitable`[`Union`[`str`, `None`]]], `None`]
+        Validation coroutine
+
+    optional: `Union`[`bool`, `None`]
+        If the input form field is optional
+    """
+
     def __init__(self, id: str, validate: Callable[[  # pylint: disable=redefined-builtin
                  str], Awaitable[Union[str, None]]], optional: bool):
         self.id = id


### PR DESCRIPTION
## Summary of change

Added the `docstrings` to the `emailpassword` recipe interface classes.
This results in providing documentation with `help()` function of python, API documentation in the `pdocs` output and documentation in the `vscode IntelliSense`.
  
## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
