### PR TITLE
fix!: removes unnecessary dependencies + changes fastapi middleware import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.0] - 2022-03-26
+
+### Changes
+- Removes dependency on framework specific dependencies (`werkzeug` and `starlette`)
+
+### Breaking change:
+- Import for fastapi middleware:
+   - Old
+      ```
+      from supertokens_python.framework.fastapi import Middleware
+
+      app = FastAPI()
+      app.add_middleware(Middleware)
+      ```
+   - New
+      ```
+      from supertokens_python.framework.fastapi import get_middleware
+
+      app = FastAPI()
+      app.add_middleware(get_middleware())
+      ```
+
 ## [0.5.3] - 2022-03-26
 ### Fixes
 - Bug in user pagination functions: https://github.com/supertokens/supertokens-python/issues/95

--- a/examples/with-fastapi/with-thirdpartyemailpassword/main.py
+++ b/examples/with-fastapi/with-thirdpartyemailpassword/main.py
@@ -12,7 +12,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp
 from supertokens_python import (InputAppInfo, SupertokensConfig,
                                 get_all_cors_headers, init)
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import session, thirdpartyemailpassword
 from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.framework.fastapi import verify_session
@@ -22,7 +22,7 @@ from supertokens_python.recipe.thirdpartyemailpassword import (
 load_dotenv()
 
 app = FastAPI(debug=True)
-app.add_middleware(Middleware)
+app.add_middleware(get_middleware())
 os.environ.setdefault('SUPERTOKENS_ENV', 'testing')
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,15 +26,15 @@ extras_require = {
     ]),
     'fastapi': ([
         'respx==0.16.3',
-        'Fastapi==0.68.1'
+        'Fastapi'
     ]),
     'flask': ([
         'flask_cors',
-        'Flask==2.0.2'
+        'Flask'
     ]),
     'django': ([
         'django-cors-headers==3.11.0',
-        'django==3.2.12',
+        'django',
         'django-stubs==1.9.0'
     ])
 }
@@ -84,18 +84,16 @@ setup(
     ],
     keywords="",
     install_requires=[
-        "PyJWT==2.0.*",
-        "httpx==0.15.*",
-        "pycryptodome==3.10.*",
-        'jsonschema==3.2.0',
-        "tldextract==3.1.0",
-        "asgiref==3.4.1",
-        "werkzeug==2.0.1",
-        'starlette~=0.14.2',
-        'typing_extensions==4.1.1',
-        'Deprecated==1.2.13',
-        'cryptography==35.0',
-        'phonenumbers==8.12'
+        "PyJWT~=2.0",
+        "httpx~=0.15",
+        "pycryptodome~=3.10",
+        'jsonschema~=3.2',
+        "tldextract~=3.1",
+        "asgiref~=3.4",
+        'typing_extensions~=4.1',
+        'Deprecated~=1.2',
+        'cryptography~=35.0',
+        'phonenumbers~=8.12'
     ],
     python_requires='>=3.7',
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.5.3",
+    version="0.6.0",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12']
-VERSION = '0.5.3'
+VERSION = '0.6.0'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'

--- a/supertokens_python/framework/fastapi/__init__.py
+++ b/supertokens_python/framework/fastapi/__init__.py
@@ -12,4 +12,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from supertokens_python.framework.fastapi import fastapi_middleware
-Middleware = fastapi_middleware.Middleware
+
+get_middleware = fastapi_middleware.get_middleware

--- a/supertokens_python/framework/fastapi/fastapi_middleware.py
+++ b/supertokens_python/framework/fastapi/fastapi_middleware.py
@@ -15,48 +15,53 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Union
 
-from starlette.middleware.base import (BaseHTTPMiddleware,
-                                       RequestResponseEndpoint)
 from supertokens_python.framework import BaseResponse
 
 if TYPE_CHECKING:
     from fastapi import FastAPI, Request
 
 
-class Middleware(BaseHTTPMiddleware):
+def get_middleware():
+    from starlette.middleware.base import (BaseHTTPMiddleware,
+                                           RequestResponseEndpoint)
 
-    def __init__(self, app: FastAPI):
-        super().__init__(app)
+    class Middleware(BaseHTTPMiddleware):
 
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
-        from supertokens_python import Supertokens
-        from supertokens_python.exceptions import SuperTokensError
-        from supertokens_python.framework.fastapi.fastapi_request import \
-            FastApiRequest
-        from supertokens_python.framework.fastapi.fastapi_response import \
-            FastApiResponse
-        from supertokens_python.recipe.session import SessionContainer
-        from supertokens_python.supertokens import manage_cookies_post_response
-        st = Supertokens.get_instance()
-        from fastapi.responses import Response
+        def __init__(self, app: FastAPI):
+            super().__init__(app)
 
-        try:
-            custom_request = FastApiRequest(request)
-            response = FastApiResponse(Response())
-            result: Union[BaseResponse, None] = await st.middleware(custom_request, response)
-            if result is None:
-                response = await call_next(request)
-                result = FastApiResponse(response)
+        async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+            from supertokens_python import Supertokens
+            from supertokens_python.exceptions import SuperTokensError
+            from supertokens_python.framework.fastapi.fastapi_request import \
+                FastApiRequest
+            from supertokens_python.framework.fastapi.fastapi_response import \
+                FastApiResponse
+            from supertokens_python.recipe.session import SessionContainer
+            from supertokens_python.supertokens import \
+                manage_cookies_post_response
+            st = Supertokens.get_instance()
+            from fastapi.responses import Response
 
-            if hasattr(request.state, "supertokens") and isinstance(
-                    request.state.supertokens, SessionContainer):
-                manage_cookies_post_response(request.state.supertokens, result)
-            if isinstance(result, FastApiResponse):
-                return result.response
-        except SuperTokensError as e:
-            response = FastApiResponse(Response())
-            result: Union[BaseResponse, None] = await st.handle_supertokens_error(FastApiRequest(request), e, response)
-            if isinstance(result, FastApiResponse):
-                return result.response
+            try:
+                custom_request = FastApiRequest(request)
+                response = FastApiResponse(Response())
+                result: Union[BaseResponse, None] = await st.middleware(custom_request, response)
+                if result is None:
+                    response = await call_next(request)
+                    result = FastApiResponse(response)
 
-        raise Exception("Should never come here")
+                if hasattr(request.state, "supertokens") and isinstance(
+                        request.state.supertokens, SessionContainer):
+                    manage_cookies_post_response(request.state.supertokens, result)
+                if isinstance(result, FastApiResponse):
+                    return result.response
+            except SuperTokensError as e:
+                response = FastApiResponse(Response())
+                result: Union[BaseResponse, None] = await st.handle_supertokens_error(FastApiRequest(request), e, response)
+                if isinstance(result, FastApiResponse):
+                    return result.response
+
+            raise Exception("Should never come here")
+
+    return Middleware

--- a/supertokens_python/framework/flask/flask_response.py
+++ b/supertokens_python/framework/flask/flask_response.py
@@ -15,7 +15,6 @@ import json
 from typing import Any, Dict, List, Union
 
 from supertokens_python.framework.response import BaseResponse
-from werkzeug.http import dump_cookie
 
 
 class FlaskResponse(BaseResponse):
@@ -36,6 +35,7 @@ class FlaskResponse(BaseResponse):
 
     def set_cookie(self, key: str, value: str, expires: int, path: str = "/",
                    domain: Union[str, None] = None, secure: bool = False, httponly: bool = False, samesite: str = "lax"):
+        from werkzeug.http import dump_cookie
         if self.response is None:
             cookie = dump_cookie(
                 key,

--- a/tests/Fastapi/test_fastapi.py
+++ b/tests/Fastapi/test_fastapi.py
@@ -19,7 +19,7 @@ from fastapi.requests import Request
 from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import emailpassword, session
 from supertokens_python.recipe.emailpassword.interfaces import \
     APIInterface as EPAPIInterface
@@ -51,7 +51,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.get('/login')
     async def login(request: Request):  # type: ignore

--- a/tests/auth-react/fastapi-server/app.py
+++ b/tests/auth-react/fastapi-server/app.py
@@ -28,7 +28,7 @@ from starlette.responses import Response
 from starlette.types import ASGIApp
 from supertokens_python import (InputAppInfo, Supertokens, SupertokensConfig,
                                 get_all_cors_headers, init)
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import (emailpassword, passwordless, session,
                                        thirdparty, thirdpartyemailpassword,
                                        thirdpartypasswordless)
@@ -56,7 +56,7 @@ from typing_extensions import Literal
 load_dotenv()
 
 app = FastAPI(debug=True)
-app.add_middleware(Middleware)
+app.add_middleware(get_middleware())
 os.environ.setdefault('SUPERTOKENS_ENV', 'testing')
 
 code_store: Dict[str, List[Dict[str, Any]]] = {}

--- a/tests/emailpassword/test_emailexists.py
+++ b/tests/emailpassword/test_emailexists.py
@@ -11,18 +11,18 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import Union
-from supertokens_python.recipe.session import SessionContainer
 import json
+from typing import Union
 
 from fastapi import FastAPI
 from fastapi.requests import Request
 from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import emailpassword, session
 from supertokens_python.recipe.emailpassword.interfaces import APIInterface
+from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.asyncio import (create_new_session,
                                                        get_session,
                                                        refresh_session)
@@ -43,7 +43,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.get('/login')
     async def login(request: Request):  # type: ignore

--- a/tests/emailpassword/test_emailverify.py
+++ b/tests/emailpassword/test_emailverify.py
@@ -21,7 +21,7 @@ from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.exceptions import BadInputError
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import emailpassword, session
 from supertokens_python.recipe.emailpassword.asyncio import (
@@ -56,7 +56,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.get('/login')
     async def login(request: Request):  # type: ignore

--- a/tests/emailpassword/test_passwordreset.py
+++ b/tests/emailpassword/test_passwordreset.py
@@ -11,20 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import Union
-from supertokens_python.recipe.emailpassword.types import User
-from typing import Any, Dict
-from supertokens_python.recipe.session import SessionContainer
 import asyncio
 import json
+from typing import Any, Dict, Union
 
 from fastapi import FastAPI
 from fastapi.requests import Request
 from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import emailpassword, session
+from supertokens_python.recipe.emailpassword.types import User
+from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.asyncio import (create_new_session,
                                                        get_session,
                                                        refresh_session)
@@ -45,7 +44,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.get('/login')
     async def login(request: Request):  # type: ignore

--- a/tests/emailpassword/test_signin.py
+++ b/tests/emailpassword/test_signin.py
@@ -11,9 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import Union
-from supertokens_python.recipe.session import SessionContainer
 import json
+from typing import Union
 
 from fastapi import FastAPI
 from fastapi.requests import Request
@@ -21,10 +20,11 @@ from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.asyncio import delete_user, get_user_count
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import emailpassword, session
 from supertokens_python.recipe.emailpassword.interfaces import APIInterface
+from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.asyncio import (create_new_session,
                                                        get_session,
                                                        refresh_session)
@@ -47,7 +47,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.get('/login')
     async def login(request: Request):  # type: ignore

--- a/tests/frontendIntegration/fastapi-server/app.py
+++ b/tests/frontendIntegration/fastapi-server/app.py
@@ -11,16 +11,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict
-from supertokens_python.recipe.session.interfaces import (APIInterface,
-                                                          RecipeInterface)
-from supertokens_python.framework import BaseRequest, BaseResponse
 import json
 import os
 import sys
-from typing import Union
-
-from typing_extensions import Literal
+from typing import Any, Dict, Union
 
 import uvicorn  # type: ignore
 from fastapi import Depends, FastAPI
@@ -30,19 +24,23 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from supertokens_python import (InputAppInfo, Supertokens, SupertokensConfig,
                                 get_all_cors_headers, init)
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework import BaseRequest, BaseResponse
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session import InputErrorHandlers
 from supertokens_python.recipe.session.asyncio import (
     SessionContainer, SessionRecipe, create_new_session,
     revoke_all_sessions_for_user)
 from supertokens_python.recipe.session.framework.fastapi import verify_session
+from supertokens_python.recipe.session.interfaces import (APIInterface,
+                                                          RecipeInterface)
+from typing_extensions import Literal
 
 index_file = open("templates/index.html", "r")
 file_contents = index_file.read()
 index_file.close()
 app = FastAPI(debug=True)
-app.add_middleware(Middleware)
+app.add_middleware(get_middleware())
 os.environ.setdefault('SUPERTOKENS_ENV', 'testing')
 
 last_set_enable_anti_csrf = True

--- a/tests/jwt/test_get_JWKS.py
+++ b/tests/jwt/test_get_JWKS.py
@@ -20,7 +20,7 @@ from pytest import mark
 from starlette.requests import Request
 from starlette.testclient import TestClient
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import jwt
 from supertokens_python.recipe.jwt.interfaces import APIInterface
 from supertokens_python.recipe.session.asyncio import create_new_session
@@ -41,7 +41,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.get('/login')
     async def login(request: Request):  # type: ignore

--- a/tests/jwt/test_override.py
+++ b/tests/jwt/test_override.py
@@ -14,18 +14,18 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
-from supertokens_python.recipe.jwt.interfaces import APIOptions
 from typing import Any, Dict, List, Union
+
 from _pytest.fixtures import fixture
 from fastapi import FastAPI
 from pytest import mark
 from starlette.requests import Request
 from starlette.testclient import TestClient
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import jwt
 from supertokens_python.recipe.jwt.asyncio import create_jwt
-from supertokens_python.recipe.jwt.interfaces import (APIInterface,
+from supertokens_python.recipe.jwt.interfaces import (APIInterface, APIOptions,
                                                       RecipeInterface)
 from tests.utils import clean_st, reset, setup_st, start_st
 
@@ -44,7 +44,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     @app.post('/jwtcreate')
     async def jwt_create(request: Request):  # type: ignore

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,7 +14,7 @@
 
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import emailpassword, session
 
 from fastapi import FastAPI
@@ -36,7 +36,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
     return TestClient(app)
 
 

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -11,16 +11,16 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from supertokens_python.recipe.emailpassword.types import FormField
-from supertokens_python.recipe.emailpassword.interfaces import APIOptions
 from typing import Any, Dict, List, Union
+
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.framework.fastapi import Middleware
+from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import emailpassword, session
 from supertokens_python.recipe.emailpassword.asyncio import sign_up
 from supertokens_python.recipe.emailpassword.interfaces import (
-    APIInterface, RecipeInterface)
+    APIInterface, APIOptions, RecipeInterface)
+from supertokens_python.recipe.emailpassword.types import FormField
 from supertokens_python.recipe.session.interfaces import \
     RecipeInterface as SRecipeInterface
 
@@ -47,7 +47,7 @@ def teardown_function(_):
 @fixture(scope='function')
 async def driver_config_client():
     app = FastAPI()
-    app.add_middleware(Middleware)
+    app.add_middleware(get_middleware())
 
     return TestClient(app)
 


### PR DESCRIPTION
## Summary of change

Removes dependency from framework being used. This is a breaking change cause the way fastapi middleware was being exposed needed to be changed cause we couldn't import `starlette` on the top level.