### PR TITLE
fix: Expands allowed version range for dependency httpx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install-with-fastapi
+      - run: make with-fastapi
       - run: (cd .circleci/ && ./websiteFastApi.sh)
       - slack/status
   test-website-flask:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install-with-flask
+      - run: make with-flask
       - run: (cd .circleci/ && ./websiteFlask.sh)
       - slack/status
   test-website-django:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install-with-django
+      - run: make with-django
       - run: (cd .circleci/ && ./websiteDjango.sh)
       - slack/status
   test-authreact-fastapi:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install-with-fastapi
+      - run: make with-fastapi
       - run: (cd .circleci/ && ./authReactFastApi.sh)
       - slack/status
   test-authreact-flask:
@@ -75,7 +75,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install-with-flask
+      - run: make with-flask
       - run: (cd .circleci/ && ./authReactFlask.sh)
       - slack/status
   test-authreact-django:
@@ -85,7 +85,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install-with-django
+      - run: make with-django
       - run: (cd .circleci/ && ./authReactDjango.sh)
       - slack/status
   test-success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.1] - 2022-03-29
+
 - Expands allowed version range for httpx library to fix https://github.com/supertokens/supertokens-python/issues/98
 
 ## [0.6.0] - 2022-03-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Expands allowed version range for httpx library to fix https://github.com/supertokens/supertokens-python/issues/98
+
 ## [0.6.0] - 2022-03-26
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,16 @@ test:
 	pytest ./tests/
 
 dev-install:
-	pip3 install -e .[dev] && pip3 install -e .[fastapi] && pip3 install -e .[django] && pip3 install -e .[flask] && pip3 install -e .[unittests] && pip3 install -e .[development]
+	pip3 install -e .[dev] && pip3 install -e .[fastapi] && pip3 install -e .[django] && pip3 install -e .[flask] && pip3 install -e .[unittests]
 
-dev-install-with-fastapi:
-	pip3 install -e .[dev] && pip3 install -e .[fastapi]
+with-fastapi:
+	pip3 install -e .[fastapi]
 
-dev-install-with-django:
-	pip3 install -e .[dev] && pip3 install -e .[django]
+with-django:
+	pip3 install -e .[django]
 
-dev-install-with-flask:
-	pip3 install -e .[dev] && pip3 install -e .[flask]
+with-flask:
+	pip3 install -e .[flask]
 
 build-docs:
 	rm -rf html && pdoc --html supertokens_python

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     keywords="",
     install_requires=[
         "PyJWT==2.0.*",
-        "httpx==0.15.*",
+        "httpx>=0.15.0 ,<=0.22.0",
         "pycryptodome==3.10.*",
         'jsonschema==3.2.0',
         "tldextract==3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ extras_require = {
         'pylint==2.12.2',
         'isort==5.10.1',
         'pyright==0.0.13',
+        'PyJWT==2.0.0'
+        'httpx==0.15.0',
         'Flask==2.0.2',
         'django==3.2.12',
         'Fastapi==0.68.1',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ with open(path.join(here, "README.md"), mode="r", encoding="utf-8") as f:
     long_description = f.read()
 
 extras_require = {
+    # we want to fix the versions of the libraries that
+    # we use to develop the SDK with otherwise we get
+    # a bunch of type errors on make dev-install depending
+    # on changes in these frameworks
     'dev': ([
         'pytest==6.2.5',
         'autopep8==1.5.6',
@@ -23,6 +27,9 @@ extras_require = {
         'pylint==2.12.2',
         'isort==5.10.1',
         'pyright==0.0.13',
+        'Flask==2.0.2',
+        'django==3.2.12',
+        'Fastapi==0.68.1',
     ]),
     'fastapi': ([
         'respx==0.16.3',
@@ -42,15 +49,6 @@ extras_require = {
     'unittests': ([
         'starlette==0.14.2'
     ]),
-    # we want to fix the versions of the framework that
-    # we use to develop the SDK with otherwise we get
-    # a bunch of type errors on make dev-install depending
-    # on changes in these frameworks
-    'development': ([
-        'Flask==2.0.2',
-        'django==3.2.12',
-        'Fastapi==0.68.1'
-    ])
 }
 
 exclude_list = [

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     ],
     keywords="",
     install_requires=[
-        "PyJWT>=2.0.0 ,<=2.3.0",
+        "PyJWT>=2.0.0 ,<2.4.0",
         "httpx>=0.15.0 ,<0.23.0",
         "pycryptodome==3.10.*",
         'jsonschema==3.2.0',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
         'pylint==2.12.2',
         'isort==5.10.1',
         'pyright==0.0.13',
-        'PyJWT==2.0.0'
+        'PyJWT==2.0.0',
         'httpx==0.15.0',
         'Flask==2.0.2',
         'django==3.2.12',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.6.0",
+    version="0.6.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,8 @@ setup(
     ],
     keywords="",
     install_requires=[
-        "PyJWT==2.0.*",
-        "httpx>=0.15.0 ,<=0.22.0",
+        "PyJWT>=2.0.0 ,<=2.3.0",
+        "httpx>=0.15.0 ,<0.23.0",
         "pycryptodome==3.10.*",
         'jsonschema==3.2.0',
         "tldextract==3.1.0",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12']
-VERSION = '0.6.0'
+VERSION = '0.6.1'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'


### PR DESCRIPTION
## Summary of change

Expand the allowed versions for the dependency `httpx`. We are importing exactly 4 classes: `AsyncClient, ConnectTimeout, NetworkError, and Response`

I've tried my best to verify the code from https://github.com/encode/httpx and read the chagelogs for any breaking change in the above mentioned classes. 

After this relaxation of the version, the https://github.com/supertokens/supertokens-python/issues/98 is gone.

![st-bugfix](https://user-images.githubusercontent.com/47217984/160596020-dd46ebfc-b581-4d3f-a15f-52aff020ee03.png)

`supertokens-python` and `fastapi-mail` can now co-exist :)

## Related issues

- https://github.com/supertokens/supertokens-python/issues/98

## Test Plan

Screenshot provided above.

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
