### PR TITLE
fix: Add missing dotenv from framework specific dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,20 @@ extras_require = {
     'fastapi': ([
         'respx==0.16.3',
         'Fastapi',
-        'uvicorn==0.13.4'
+        'uvicorn==0.13.4',
+        'python-dotenv==0.19.2',
     ]),
     'flask': ([
         'flask_cors',
-        'Flask'
+        'Flask',
+        'python-dotenv==0.19.2',
     ]),
     'django': ([
         'django-cors-headers==3.11.0',
         'django',
         'django-stubs==1.9.0',
-        'uvicorn==0.13.4'
+        'uvicorn==0.13.4',
+        'python-dotenv==0.19.2',
     ]),
     # the unit tests use fastapi testClient,
     # and it only works with this version of starlette


### PR DESCRIPTION
## Summary of change

setup.py: Adding missing dotenv in framework specific dependencies

## Test Plan


## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
