### PR TITLE
fix: Use Passwordless OTP recipe phone number field and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.2] - 2022-04-07
+- Fix Passwordless OTP recipe phone number field to fix https://github.com/supertokens/supertokens-core/issues/416
+
 ## [0.6.1] - 2022-03-29
 
 - Expands allowed version range for httpx library to fix https://github.com/supertokens/supertokens-python/issues/98

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.6.1",
+    version="0.6.2",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12']
-VERSION = '0.6.1'
+VERSION = '0.6.2'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'

--- a/supertokens_python/recipe/passwordless/interfaces.py
+++ b/supertokens_python/recipe/passwordless/interfaces.py
@@ -476,7 +476,7 @@ class ConsumeCodePostOkResponse(ConsumeCodePostResponse):
         if self.user.phone_number is not None:
             user = {
                 **user,
-                'phoneNumber': self.user.email
+                'phoneNumber': self.user.phone_number
             }
         return {
             'status': self.status,

--- a/supertokens_python/recipe/passwordless/recipe_implementation.py
+++ b/supertokens_python/recipe/passwordless/recipe_implementation.py
@@ -63,7 +63,7 @@ class RecipeImplementation(RecipeInterface):
         if phone_number is not None:
             data = {
                 **data,
-                'email': phone_number
+                'phone_number': phone_number
             }
         result = await self.querier.send_post_request(NormalisedURLPath('/recipe/signinup/code'), data)
         return CreateCodeOkResult(

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -72,28 +72,23 @@ async def test_passwordless_otp(driver_config_client: TestClient):
     )
     start_st()
 
-    response_1 = driver_config_client.post(
+    create_code_json = driver_config_client.post(
         url="/auth/signinup/code",
         json={
             "phoneNumber": "+919494949494",
         }
-    )
-    assert response_1.status_code == 200
-    res1_json = response_1.json()
+    ).json()
 
-    res = driver_config_client.post(
+    consume_code_json = driver_config_client.post(
         url="/auth/signinup/code/consume",
         json={
-            'preAuthSessionId': res1_json['preAuthSessionId'],
-            'deviceId': res1_json['deviceId'],
+            'preAuthSessionId': create_code_json['preAuthSessionId'],
+            'deviceId': create_code_json['deviceId'],
             'userInputCode': user_input_code,
         }
-    )
+    ).json()
 
-    assert res.status_code == 200
-    res2_json = res.json()
+    consume_code_json['user'].pop('id')
+    consume_code_json['user'].pop('time_joined')
 
-    res2_json['user'].pop('id')
-    res2_json['user'].pop('time_joined')
-
-    assert res2_json == {'status': 'OK', 'createdNewUser': True, 'user': {'phoneNumber': '+919494949494'}}
+    assert consume_code_json == {'status': 'OK', 'createdNewUser': True, 'user': {'phoneNumber': '+919494949494'}}

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -49,7 +49,6 @@ async def test_passwordless_otp(driver_config_client: TestClient):
     user_input_code = None
 
     async def send_text_message(param: passwordless.CreateAndSendCustomTextMessageParameters, user_context: Dict[str, Any]):
-        print(param)
         nonlocal user_input_code
         user_input_code = param.user_input_code
 

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest import fixture, mark
+from supertokens_python import InputAppInfo, SupertokensConfig, init
+from supertokens_python.framework.fastapi import get_middleware
+from supertokens_python.recipe import passwordless, session
+
+from tests.utils import clean_st, reset, setup_st, start_st
+
+
+def setup_function(_):
+    reset()
+    clean_st()
+    setup_st()
+
+
+def teardown_function(_):
+    reset()
+    clean_st()
+
+
+@fixture(scope='function')
+async def driver_config_client():
+    app = FastAPI()
+    app.add_middleware(get_middleware())
+
+    return TestClient(app)
+
+
+@mark.asyncio
+async def test_passwordless_otp(driver_config_client: TestClient):
+    user_input_code = None
+
+    async def send_text_message(param: passwordless.CreateAndSendCustomTextMessageParameters, user_context: Dict[str, Any]):
+        print(param)
+        nonlocal user_input_code
+        user_input_code = param.user_input_code
+
+    init(
+        supertokens_config=SupertokensConfig('http://localhost:3567'),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="http://api.supertokens.io",
+            website_domain="http://supertokens.io",
+            api_base_path="/auth"
+        ),
+        framework='fastapi',
+        recipe_list=[passwordless.init(
+            flow_type="USER_INPUT_CODE",
+            contact_config=passwordless.ContactPhoneOnlyConfig(
+                create_and_send_custom_text_message=send_text_message
+            )
+        ),
+            session.init()
+        ]
+    )
+    start_st()
+
+    response_1 = driver_config_client.post(
+        url="/auth/signinup/code",
+        json={
+            "phoneNumber": "+919494949494",
+        }
+    )
+    assert response_1.status_code == 200
+    res1_json = response_1.json()
+
+    res = driver_config_client.post(
+        url="/auth/signinup/code/consume",
+        json={
+            'preAuthSessionId': res1_json['preAuthSessionId'],
+            'deviceId': res1_json['deviceId'],
+            'userInputCode': user_input_code,
+        }
+    )
+
+    assert res.status_code == 200
+    res2_json = res.json()
+
+    res2_json['user'].pop('id')
+    res2_json['user'].pop('time_joined')
+
+    assert res2_json == {'status': 'OK', 'createdNewUser': True, 'user': {'phoneNumber': '+919494949494'}}


### PR DESCRIPTION
## Summary of change

The phone number in the passwordless OTP recipe was getting stored in the email field. This PR fixes that bug. 


## Related issues

-   Fixes https://github.com/supertokens/supertokens-core/issues/416

## Test Plan

- Added `test_passwordless.py` file

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 