### PR TITLE
fix: Skip test_passwordless_otp test if core version < 2.11.0

### DIFF
--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -15,13 +15,15 @@
 
 from typing import Any, Dict
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.framework.fastapi import get_middleware
+from supertokens_python.querier import Querier
 from supertokens_python.recipe import passwordless, session
+from supertokens_python.utils import compare_version
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from tests.utils import clean_st, reset, setup_st, start_st
 
 
@@ -71,6 +73,11 @@ async def test_passwordless_otp(driver_config_client: TestClient):
         ]
     )
     start_st()
+
+    version = await Querier.get_instance().get_api_version()
+    if compare_version(version, '2.11.0') != '2.11.0':
+        # If the version less than 2.11.0, passwordless OTP doesn't exist. So skip the test
+        return
 
     create_code_json = driver_config_client.post(
         url="/auth/signinup/code",


### PR DESCRIPTION
## Summary of change

Fix failure of test_passwordless_otp if core version is < 2.11.0 (Passwordless recipe didn't exist before 2.11.0)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 