### PR TITLE
feat: Rename compare_version to get_max_version for readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Renamed `compare_version` to `get_max_version` for readability
 
 ## [0.6.3] - 2022-04-09
 - Setup logging for easier debugging

--- a/supertokens_python/supertokens.py
+++ b/supertokens_python/supertokens.py
@@ -33,7 +33,7 @@ from .recipe.session.cookie_and_header import (
     attach_id_refresh_token_to_cookie_and_header,
     attach_refresh_token_to_cookie, clear_cookies, set_front_token_in_headers)
 from .types import ThirdPartyInfo, User, UsersResponse
-from .utils import (compare_version, get_rid_from_request,
+from .utils import (get_max_version, get_rid_from_request,
                     normalise_http_method, send_non_200_response)
 
 if TYPE_CHECKING:
@@ -280,7 +280,7 @@ class Supertokens:
 
         cdi_version = await querier.get_api_version()
 
-        if compare_version(cdi_version, "2.10") == cdi_version:
+        if get_max_version(cdi_version, "2.10") == cdi_version:
             await querier.send_post_request(NormalisedURLPath(USER_DELETE), {
                 "userId": user_id
             })

--- a/supertokens_python/utils.py
+++ b/supertokens_python/utils.py
@@ -73,12 +73,12 @@ def find_max_version(
     max_v = versions[0]
     for i in range(1, len(versions)):
         version = versions[i]
-        max_v = compare_version(max_v, version)
+        max_v = get_max_version(max_v, version)
 
     return max_v
 
 
-def compare_version(v1: str, v2: str) -> str:
+def get_max_version(v1: str, v2: str) -> str:
     v1_split = v1.split('.')
     v2_split = v2.split('.')
     max_loop = min(len(v1_split), len(v2_split))

--- a/tests/emailpassword/test_signin.py
+++ b/tests/emailpassword/test_signin.py
@@ -28,7 +28,7 @@ from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.asyncio import (create_new_session,
                                                        get_session,
                                                        refresh_session)
-from supertokens_python.utils import compare_version
+from supertokens_python.utils import get_max_version
 from tests.utils import (clean_st, extract_all_cookies, reset, setup_st,
                          sign_up_request, start_st)
 
@@ -574,7 +574,7 @@ async def test_delete_user(driver_config_client: TestClient):
 
     version = await Querier.get_instance().get_api_version()
 
-    if compare_version(version, "2.10") == version:
+    if get_max_version(version, "2.10") == version:
         await delete_user(dict_response["user"]["id"])
         user_count = await get_user_count()
         assert user_count == 0

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -15,15 +15,15 @@
 
 from typing import Any, Dict
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pytest import fixture, mark
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import passwordless, session
-from supertokens_python.utils import compare_version
+from supertokens_python.utils import get_max_version
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from tests.utils import clean_st, reset, setup_st, start_st
 
 
@@ -75,7 +75,7 @@ async def test_passwordless_otp(driver_config_client: TestClient):
     start_st()
 
     version = await Querier.get_instance().get_api_version()
-    if compare_version(version, '2.11.0') != version:
+    if get_max_version(version, '2.11.0') != version:
         # If the version less than 2.11.0, passwordless OTP doesn't exist. So skip the test
         return
 


### PR DESCRIPTION
## Summary of change

Rename compare_version to get_max_version for readability

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py