### PR TITLE
feat: Expand allowed version range for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-
+- Expand allowed version range for dependencies
 
 ## [0.6.3] - 2022-04-09
 - Setup logging for easier debugging

--- a/setup.py
+++ b/setup.py
@@ -81,14 +81,12 @@ setup(
     install_requires=[
         "PyJWT>=2.0.0 ,<2.4.0",
         "httpx>=0.15.0 ,<0.23.0",
-        "pycryptodome==3.10.*",
-        'jsonschema==3.2.0',
-        "tldextract==3.1.0",
-        "asgiref==3.4.1",
-        'typing_extensions==4.1.1',
-        'Deprecated==1.2.13',
-        'cryptography==35.0',
-        'phonenumbers==8.12',
+        "pycryptodome>=3.10.0 ,<3.15.0",
+        "tldextract>=3.1.0",
+        "asgiref>=3.4.1",
+        'typing_extensions>=4.1.1', # We only use Literal from typing_extensions. It's here to stay.
+        'cryptography>=3.3.1', # Its version depends on PyJWT/setup.cfg
+        'phonenumbers>=8.12 ,<8.13',
         'Werkzeug>=2.0 ,<2.1.0' # flask depends on this and flask has > '2.0' for this. However, the version before 2.1.0 breaks our lib.
     ],
     python_requires='>=3.7',


### PR DESCRIPTION
## Summary of change

Expand allowed version range for dependencies

## Test Plan

If anything breaks, the existing tests should fail in the CI.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
