### PR TITLE
fix: makes all functions in syncio usermetadata into sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.6] - 2022-04-22
+- Fixes issue in user metadata recipe where as are exposing async functions in the syncio file.
+
 ## [0.6.5] - 2022-04-18
 - Upgrade and freeze pyright version
 - Rename `compare_version` to `get_max_version` for readability

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.6.5",
+    version="0.6.6",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12', '2.13']
-VERSION = '0.6.5'
+VERSION = '0.6.6'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'

--- a/supertokens_python/recipe/usermetadata/syncio/__init__.py
+++ b/supertokens_python/recipe/usermetadata/syncio/__init__.py
@@ -3,19 +3,19 @@ from typing import Any, Dict, Union
 from supertokens_python.async_to_sync_wrapper import sync
 
 
-async def get_user_metadata(user_id: str, user_context: Union[Dict[str, Any], None] = None):
+def get_user_metadata(user_id: str, user_context: Union[Dict[str, Any], None] = None):
     from supertokens_python.recipe.usermetadata.asyncio import \
         get_user_metadata
     return sync(get_user_metadata(user_id, user_context))
 
 
-async def update_user_metadata(user_id: str, metadata_update: Dict[str, Any], user_context: Union[Dict[str, Any], None] = None):
+def update_user_metadata(user_id: str, metadata_update: Dict[str, Any], user_context: Union[Dict[str, Any], None] = None):
     from supertokens_python.recipe.usermetadata.asyncio import \
         update_user_metadata
     return sync(update_user_metadata(user_id, metadata_update, user_context))
 
 
-async def clear_user_metadata(user_id: str, user_context: Union[Dict[str, Any], None] = None):
+def clear_user_metadata(user_id: str, user_context: Union[Dict[str, Any], None] = None):
     from supertokens_python.recipe.usermetadata.asyncio import \
         clear_user_metadata
     return sync(clear_user_metadata(user_id, user_context))


### PR DESCRIPTION
## Summary of change

The usermetadata functions in the `syncio` file where exported as `async` functions. Changed them to be exported as `sync` functions - as they should have been.


## Test Plan

We should write a github PR check to make sure that the keyword "async def" doesn't appear in the `syncio.py` files

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
