### PR TITLE
fix: Fixed content length for FastAPI Response Wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- Fixed `Content-length` in FastAPI Response wrapper.
 
 ## [0.7.1] - 2022-05-06
 - Updates Project Setup, Modifying Code and Testing sections in the contributing guide
 - Fixed async execution of `send_telemetry` in init and `call_get_handshake_info` in session recipe implementation.
+- Fixed `Content-length` in FastAPI Response wrapper.
 
 ## [0.7.0] - 2022-04-28
 - Changes third party provider type to get client ID dynamically so that it can be changed based on user context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Fixed `Content-length` in FastAPI Response wrapper.
 
 ## [0.7.1] - 2022-05-06
 - Updates Project Setup, Modifying Code and Testing sections in the contributing guide

--- a/supertokens_python/framework/fastapi/fastapi_response.py
+++ b/supertokens_python/framework/fastapi/fastapi_response.py
@@ -32,8 +32,10 @@ class FastApiResponse(BaseResponse):
 
     def set_html_content(self, content: str):
         if not self.response_sent:
-            self.response.body = bytes(content, "utf-8")
+            body = bytes(content, "utf-8")
+            self.set_header('Content-Length', str(len(body)))
             self.set_header('Content-Type', 'text/html')
+            self.response.body = body
             self.response_sent = True
 
     def set_cookie(self, key: str,
@@ -68,12 +70,14 @@ class FastApiResponse(BaseResponse):
 
     def set_json_content(self, content: Dict[str, Any]):
         if not self.response_sent:
-            self.set_header('Content-Type', 'application/json; charset=utf-8')
-            self.response.body = json.dumps(
+            body = json.dumps(
                 content,
                 ensure_ascii=False,
                 allow_nan=False,
                 indent=None,
                 separators=(",", ":"),
             ).encode("utf-8")
+            self.set_header('Content-Type', 'application/json; charset=utf-8')
+            self.set_header('Content-Length', str(len(body)))
+            self.response.body = body
             self.response_sent = True


### PR DESCRIPTION
## Summary of change

New version of FastAPI was assuming the content-length to be zero and failing to respond. Explicitly added content-length header in our FastAPI response wrapper.

## Related issues


## Test Plan

Have tested agains latest and old version. This header was not required with the old version of FastAPI, but this change safely works with old version of it as well.

## Documentation changes



## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR
