### PR TITLE
refactor: removed thirdparty_info from emailpassword `User`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates `RecipeInterface` and `APIInterface` methods to return exact return types instead of abstract base types, for the passwordless recipe.
 - Adds `EmailPasswordSignInOkResult`, `EmailPasswordSignUpOkResult` and `ThirdPartySignInUpOkResult` to use the thirdpartyemailpassword recipe's `User` class.
 - Adds `ThirdPartySignInUpPostOkResponse`, `EmailPasswordSignInPostOkResponse` and `EmailPasswordSignUpPostOkResponse` to use the thirdpartyemailpassword recipe's `User` class.
+- Removed `third_party_info` from emailpassword `User` class.
+
 
 ## [0.6.7] - 2022-04-23
 - Adds delete email (`delete_email_for_user`) and phone number (`delete_phone_number_for_user`) functions for passwordless and thirdpartypasswordless recipe

--- a/supertokens_python/recipe/emailpassword/types.py
+++ b/supertokens_python/recipe/emailpassword/types.py
@@ -19,7 +19,6 @@ class User:
         self.user_id: str = user_id
         self.email: str = email
         self.time_joined: int = time_joined
-        self.third_party_info: None = None
 
 
 class UsersResponse:


### PR DESCRIPTION
## Summary of change

Emailpassword types has a `User` class has `third_party_info` always set to `None` which is not required. Removed it

## Related issues


## Test Plan


## Documentation changes


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR
