### PR TITLE
refactor: normalised return types for usermetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates `RecipeInterface` and `APIInterface` methods to return exact return types instead of abstract base types, for the openid recipe.
 - Updates `RecipeInterface` and `APIInterface` methods to return exact return types instead of abstract base types, for the JWT recipe.
 - Updates `RecipeInterface` and `APIInterface` methods to return exact return types instead of abstract base types, for the session recipe.
+- Updates `RecipeInterface` methods to return exact return types instead of abstract base types, for the usermetadata recipe.
 
 ## [0.6.7] - 2022-04-23
 - Adds delete email (`delete_email_for_user`) and phone number (`delete_phone_number_for_user`) functions for passwordless and thirdpartypasswordless recipe

--- a/supertokens_python/recipe/usermetadata/interfaces.py
+++ b/supertokens_python/recipe/usermetadata/interfaces.py
@@ -1,20 +1,14 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from typing_extensions import Literal
-
 
 class MetadataResult(ABC):
-    def __init__(self, status: Literal['OK'], metadata: Dict[str, Any]):
-        self.status = status
-        self.is_ok = status == 'OK'
+    def __init__(self, metadata: Dict[str, Any]):
         self.metadata = metadata
 
 
-class ClearUserMetadataResult(ABC):
-    def __init__(self, status: Literal['OK']):
-        self.status = status
-        self.is_ok = status == 'OK'
+class ClearUserMetadataResult():
+    pass
 
 
 class RecipeInterface(ABC):

--- a/supertokens_python/recipe/usermetadata/recipe_implementation.py
+++ b/supertokens_python/recipe/usermetadata/recipe_implementation.py
@@ -30,20 +30,14 @@ class RecipeImplementation(RecipeInterface):
     async def get_user_metadata(self, user_id: str, user_context: Dict[str, Any]) -> MetadataResult:
         params = {"userId": user_id}
         response = await self.querier.send_get_request(NormalisedURLPath("/recipe/user/metadata"), params)
-        if response['status'] != 'OK':
-            raise Exception(f"Failed to get user metadata. Status: {response['status']}")
         return MetadataResult(metadata=response['metadata'])
 
     async def update_user_metadata(self, user_id: str, metadata_update: Dict[str, Any], user_context: Dict[str, Any]) -> MetadataResult:
         params = {"userId": user_id, "metadataUpdate": metadata_update}
         response = await self.querier.send_put_request(NormalisedURLPath("/recipe/user/metadata"), params)
-        if response['status'] != 'OK':
-            raise Exception(f"Failed to update user metadata. Status: {response['status']}")
         return MetadataResult(metadata=response['metadata'])
 
     async def clear_user_metadata(self, user_id: str, user_context: Dict[str, Any]) -> ClearUserMetadataResult:
         params = {"userId": user_id}
-        response = await self.querier.send_post_request(NormalisedURLPath("/recipe/user/metadata/remove"), params)
-        if response['status'] != 'OK':
-            raise Exception(f"Failed to clear user metadata. Status: {response['status']}")
+        await self.querier.send_post_request(NormalisedURLPath("/recipe/user/metadata/remove"), params)
         return ClearUserMetadataResult()

--- a/supertokens_python/recipe/usermetadata/recipe_implementation.py
+++ b/supertokens_python/recipe/usermetadata/recipe_implementation.py
@@ -30,14 +30,20 @@ class RecipeImplementation(RecipeInterface):
     async def get_user_metadata(self, user_id: str, user_context: Dict[str, Any]) -> MetadataResult:
         params = {"userId": user_id}
         response = await self.querier.send_get_request(NormalisedURLPath("/recipe/user/metadata"), params)
-        return MetadataResult(status=response['status'], metadata=response['metadata'])
+        if response['status'] != 'OK':
+            raise Exception(f"Failed to get user metadata. Status: {response['status']}")
+        return MetadataResult(metadata=response['metadata'])
 
     async def update_user_metadata(self, user_id: str, metadata_update: Dict[str, Any], user_context: Dict[str, Any]) -> MetadataResult:
         params = {"userId": user_id, "metadataUpdate": metadata_update}
         response = await self.querier.send_put_request(NormalisedURLPath("/recipe/user/metadata"), params)
-        return MetadataResult(status=response['status'], metadata=response['metadata'])
+        if response['status'] != 'OK':
+            raise Exception(f"Failed to update user metadata. Status: {response['status']}")
+        return MetadataResult(metadata=response['metadata'])
 
     async def clear_user_metadata(self, user_id: str, user_context: Dict[str, Any]) -> ClearUserMetadataResult:
         params = {"userId": user_id}
         response = await self.querier.send_post_request(NormalisedURLPath("/recipe/user/metadata/remove"), params)
-        return ClearUserMetadataResult(status=response['status'])
+        if response['status'] != 'OK':
+            raise Exception(f"Failed to clear user metadata. Status: {response['status']}")
+        return ClearUserMetadataResult()

--- a/tests/usermetadata/test_metadata.py
+++ b/tests/usermetadata/test_metadata.py
@@ -20,7 +20,7 @@ from supertokens_python.querier import Querier
 from supertokens_python.recipe import usermetadata
 from supertokens_python.recipe.usermetadata.asyncio import (
     clear_user_metadata, get_user_metadata, update_user_metadata)
-from supertokens_python.recipe.usermetadata.interfaces import RecipeInterface
+from supertokens_python.recipe.usermetadata.interfaces import ClearUserMetadataResult, RecipeInterface
 from supertokens_python.recipe.usermetadata.utils import InputOverrideConfig
 from supertokens_python.utils import is_version_gte
 from tests.utils import clean_st, reset, setup_st, start_st
@@ -82,7 +82,7 @@ async def test_that_usermetadata_recipe_works_as_expected():
     assert get_metadata_res.metadata == TEST_METADATA
 
     clear_metadata_res = await clear_user_metadata(TEST_USER_ID)
-    assert clear_metadata_res.status == 'OK'
+    assert isinstance(clear_metadata_res, ClearUserMetadataResult)
 
     get_metadata_res = await get_user_metadata(TEST_USER_ID)
     assert get_metadata_res.metadata == {}


### PR DESCRIPTION
## Summary of change

Normalised return types for usermetadata, to return exact types instead of Abstract types.

## Related issues


## Test Plan


## Documentation changes


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR