### PR TITLE
refactor: added type checks for init params for emailverification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 - Adds type checks to the parameters of the emailpassword init funtion.
+- Adds type checks to the parameters of the emailverification init funtion.
 - Adds type checks to the parameters of the passwordless init funtion.
 
 ## [0.7.2] - 2022-05-08

--- a/supertokens_python/recipe/emailverification/utils.py
+++ b/supertokens_python/recipe/emailverification/utils.py
@@ -83,11 +83,18 @@ class EmailVerificationConfig:
 
 def validate_and_normalise_user_input(
         app_info: AppInfo, config: ParentRecipeEmailVerificationConfig):
+    if not isinstance(config, ParentRecipeEmailVerificationConfig):  # type: ignore
+        raise ValueError('config must be an instance of ParentRecipeEmailVerificationConfig')
+
     get_email_verification_url = config.get_email_verification_url if config.get_email_verification_url is not None \
         else default_get_email_verification_url(app_info)
     create_and_send_custom_email = config.create_and_send_custom_email if config.create_and_send_custom_email is not None \
         else default_create_and_send_custom_email(app_info)
     override = config.override
+
+    if override is not None and not isinstance(override, OverrideConfig):  # type: ignore
+        raise ValueError('override must be of type OverrideConfig or None')
+
     if override is None:
         override = OverrideConfig()
     return EmailVerificationConfig(

--- a/tests/input_validation/test_input_validation.py
+++ b/tests/input_validation/test_input_validation.py
@@ -90,8 +90,7 @@ async def test_init_validation_emailpassword():
     assert 'override must be of type InputOverrideConfig or None' == str(ex.value)
 
 
-async def get_email_for_user_id(user_id: str, user_context: Dict[str, Any]) -> str:
-    print(user_context)
+async def get_email_for_user_id(user_id: str, _: Dict[str, Any]) -> str:
     return user_id
 
 
@@ -133,8 +132,8 @@ async def test_init_validation_emailverification():
     assert 'override must be of type OverrideConfig or None' == str(ex.value)
 
 
-async def send_text_message(param: passwordless.CreateAndSendCustomTextMessageParameters, _: Dict[str, Any]):
-    print(param)
+async def send_text_message(_: passwordless.CreateAndSendCustomTextMessageParameters, __: Dict[str, Any]):
+    pass
 
 
 @pytest.mark.asyncio

--- a/tests/input_validation/test_input_validation.py
+++ b/tests/input_validation/test_input_validation.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Dict, Any
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, passwordless
+from supertokens_python.recipe import emailpassword, emailverification, passwordless
 
 
 @pytest.mark.asyncio
@@ -88,6 +88,49 @@ async def test_init_validation_emailpassword():
             ]
         )
     assert 'override must be of type InputOverrideConfig or None' == str(ex.value)
+
+
+async def get_email_for_user_id(user_id: str, user_context: Dict[str, Any]) -> str:
+    print(user_context)
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_init_validation_emailverification():
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                emailverification.init('config')  # type: ignore
+            ]
+        )
+    assert 'config must be an instance of ParentRecipeEmailVerificationConfig' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                emailverification.init(
+                    emailverification.ParentRecipeEmailVerificationConfig(
+                        get_email_for_user_id=get_email_for_user_id,
+                        override='override'))  # type: ignore
+            ]
+        )
+    assert 'override must be of type OverrideConfig or None' == str(ex.value)
 
 
 async def send_text_message(param: passwordless.CreateAndSendCustomTextMessageParameters, _: Dict[str, Any]):


### PR DESCRIPTION
## Summary of change

User might not have enabled linting with their IDE, might end up passing wrong types which is not caught early within the SDK. Added type checks for the emailverification recipe.

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/128


## Test Plan

Added unit tests.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR
