### PR TITLE
refactor: exported re-used classes and cleaning up imports for clarity (thirdpartypasswordless)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 - Exports re-used Result and Response classes from `thirdparty` & `emailpassword` recipe interfaces in the `thirdpartyemailpassword` recipe interfaces.
+- Exports re-used Result and Response classes from `thirdparty` & `passwordless` recipe interfaces in the `thirdpartypasswordless` recipe interfaces.
 
 ## [0.8.0]
 - Updates `RecipeInterface` and `APIInterface` methods to return exact return types instead of abstract base types, for the email password recipe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Exports re-used Result and Response classes from `thirdparty` & `emailpassword` recipe interfaces in the `thirdpartyemailpassword` recipe interfaces.
 
 ## [0.8.0]
 - Updates `RecipeInterface` and `APIInterface` methods to return exact return types instead of abstract base types, for the email password recipe.

--- a/supertokens_python/recipe/thirdpartyemailpassword/interfaces.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/interfaces.py
@@ -18,24 +18,24 @@ EmailPasswordAPIOptions = EPInterfaces.APIOptions
 # Exporting re-used classes
 CreateResetPasswordOkResult = EPInterfaces.CreateResetPasswordOkResult
 CreateResetPasswordWrongUserIdErrorResult = EPInterfaces.CreateResetPasswordWrongUserIdErrorResult
-EmailExistsGetOkResponse = EPInterfaces.EmailExistsGetOkResponse
+EmailPasswordEmailExistsGetOkResponse = EPInterfaces.EmailExistsGetOkResponse
 GeneratePasswordResetTokenPostOkResponse = EPInterfaces.GeneratePasswordResetTokenPostOkResponse
 PasswordResetPostInvalidTokenResponse = EPInterfaces.PasswordResetPostInvalidTokenResponse
 PasswordResetPostOkResponse = EPInterfaces.PasswordResetPostOkResponse
 ResetPasswordUsingTokenInvalidTokenErrorResult = EPInterfaces.ResetPasswordUsingTokenInvalidTokenErrorResult
 ResetPasswordUsingTokenOkResult = EPInterfaces.ResetPasswordUsingTokenOkResult
-SignInPostWrongCredentialsErrorResponse = EPInterfaces.SignInPostWrongCredentialsErrorResponse
-SignInWrongCredentialsErrorResult = EPInterfaces.SignInWrongCredentialsErrorResult
-SignUpEmailAlreadyExistsErrorResult = EPInterfaces.SignUpEmailAlreadyExistsErrorResult
-SignUpPostEmailAlreadyExistsErrorResponse = EPInterfaces.SignUpPostEmailAlreadyExistsErrorResponse
+EmailPasswordSignInPostWrongCredentialsErrorResponse = EPInterfaces.SignInPostWrongCredentialsErrorResponse
+EmailPasswordSignInWrongCredentialsErrorResult = EPInterfaces.SignInWrongCredentialsErrorResult
+EmailPasswordSignUpEmailAlreadyExistsErrorResult = EPInterfaces.SignUpEmailAlreadyExistsErrorResult
+EmailPasswordSignUpPostEmailAlreadyExistsErrorResponse = EPInterfaces.SignUpPostEmailAlreadyExistsErrorResponse
 UpdateEmailOrPasswordEmailAlreadyExistsErrorResult = EPInterfaces.UpdateEmailOrPasswordEmailAlreadyExistsErrorResult
 UpdateEmailOrPasswordOkResult = EPInterfaces.UpdateEmailOrPasswordOkResult
 UpdateEmailOrPasswordUnknownUserIdErrorResult = EPInterfaces.UpdateEmailOrPasswordUnknownUserIdErrorResult
 
 AuthorisationUrlGetOkResponse = ThirdPartyInterfaces.AuthorisationUrlGetOkResponse
-SignInUpFieldErrorResult = ThirdPartyInterfaces.SignInUpFieldErrorResult
-SignInUpPostNoEmailGivenByProviderResponse = ThirdPartyInterfaces.SignInUpPostNoEmailGivenByProviderResponse
-SignInUpPostFieldErrorResponse = ThirdPartyInterfaces.SignInUpPostFieldErrorResponse
+ThirdPartySignInUpFieldErrorResult = ThirdPartyInterfaces.SignInUpFieldErrorResult
+ThirdPartySignInUpPostNoEmailGivenByProviderResponse = ThirdPartyInterfaces.SignInUpPostNoEmailGivenByProviderResponse
+ThirdPartySignInUpPostFieldErrorResponse = ThirdPartyInterfaces.SignInUpPostFieldErrorResponse
 
 
 class ThirdPartySignInUpOkResult():
@@ -73,15 +73,15 @@ class RecipeInterface(ABC):
 
     @abstractmethod
     async def thirdparty_sign_in_up(self, third_party_id: str, third_party_user_id: str, email: str,
-                                    email_verified: bool, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpOkResult, SignInUpFieldErrorResult]:
+                                    email_verified: bool, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpOkResult, ThirdPartySignInUpFieldErrorResult]:
         pass
 
     @abstractmethod
-    async def emailpassword_sign_in(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInOkResult, SignInWrongCredentialsErrorResult]:
+    async def emailpassword_sign_in(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInOkResult, EmailPasswordSignInWrongCredentialsErrorResult]:
         pass
 
     @abstractmethod
-    async def emailpassword_sign_up(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpOkResult, SignUpEmailAlreadyExistsErrorResult]:
+    async def emailpassword_sign_up(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpOkResult, EmailPasswordSignUpEmailAlreadyExistsErrorResult]:
         pass
 
     @abstractmethod
@@ -182,21 +182,21 @@ class APIInterface(ABC):
 
     @abstractmethod
     async def thirdparty_sign_in_up_post(self, provider: Provider, code: str, redirect_uri: str, client_id: Union[str, None], auth_code_response: Union[Dict[str, Any], None],
-                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse]:
+                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, ThirdPartySignInUpPostNoEmailGivenByProviderResponse, ThirdPartySignInUpPostFieldErrorResponse]:
         pass
 
     @abstractmethod
     async def emailpassword_sign_in_post(self, form_fields: List[FormField],
-                                         api_options: EmailPasswordAPIOptions, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInPostOkResponse, SignInPostWrongCredentialsErrorResponse]:
+                                         api_options: EmailPasswordAPIOptions, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInPostOkResponse, EmailPasswordSignInPostWrongCredentialsErrorResponse]:
         pass
 
     @abstractmethod
     async def emailpassword_sign_up_post(self, form_fields: List[FormField],
-                                         api_options: EmailPasswordAPIOptions, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpPostOkResponse, SignUpPostEmailAlreadyExistsErrorResponse]:
+                                         api_options: EmailPasswordAPIOptions, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpPostOkResponse, EmailPasswordSignUpPostEmailAlreadyExistsErrorResponse]:
         pass
 
     @abstractmethod
-    async def emailpassword_email_exists_get(self, email: str, api_options: EmailPasswordAPIOptions, user_context: Dict[str, Any]) -> EmailExistsGetOkResponse:
+    async def emailpassword_email_exists_get(self, email: str, api_options: EmailPasswordAPIOptions, user_context: Dict[str, Any]) -> EmailPasswordEmailExistsGetOkResponse:
         pass
 
     @abstractmethod

--- a/supertokens_python/recipe/thirdpartyemailpassword/interfaces.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/interfaces.py
@@ -2,25 +2,11 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Union
 
 from supertokens_python.recipe.emailpassword import interfaces as EPInterfaces
-from supertokens_python.recipe.emailpassword.interfaces import (
-    CreateResetPasswordOkResult, CreateResetPasswordWrongUserIdErrorResult,
-    EmailExistsGetOkResponse, GeneratePasswordResetTokenPostOkResponse,
-    PasswordResetPostInvalidTokenResponse, PasswordResetPostOkResponse,
-    ResetPasswordUsingTokenInvalidTokenErrorResult,
-    ResetPasswordUsingTokenOkResult,
-    SignInPostWrongCredentialsErrorResponse, SignInWrongCredentialsErrorResult,
-    SignUpEmailAlreadyExistsErrorResult,
-    SignUpPostEmailAlreadyExistsErrorResponse,
-    UpdateEmailOrPasswordEmailAlreadyExistsErrorResult,
-    UpdateEmailOrPasswordOkResult,
-    UpdateEmailOrPasswordUnknownUserIdErrorResult)
 from supertokens_python.recipe.emailpassword.types import FormField
+
 from supertokens_python.recipe.session import SessionContainer
-from supertokens_python.recipe.thirdparty import \
-    interfaces as ThirdPartyInterfaces
-from supertokens_python.recipe.thirdparty.interfaces import (
-    AuthorisationUrlGetOkResponse, SignInUpFieldErrorResult,
-    SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse)
+
+from supertokens_python.recipe.thirdparty import interfaces as ThirdPartyInterfaces
 from supertokens_python.recipe.thirdparty.provider import Provider
 from supertokens_python.types import APIResponse
 
@@ -28,6 +14,28 @@ from .types import User
 
 ThirdPartyAPIOptions = ThirdPartyInterfaces.APIOptions
 EmailPasswordAPIOptions = EPInterfaces.APIOptions
+
+# Exporting re-used classes
+CreateResetPasswordOkResult = EPInterfaces.CreateResetPasswordOkResult
+CreateResetPasswordWrongUserIdErrorResult = EPInterfaces.CreateResetPasswordWrongUserIdErrorResult
+EmailExistsGetOkResponse = EPInterfaces.EmailExistsGetOkResponse
+GeneratePasswordResetTokenPostOkResponse = EPInterfaces.GeneratePasswordResetTokenPostOkResponse
+PasswordResetPostInvalidTokenResponse = EPInterfaces.PasswordResetPostInvalidTokenResponse
+PasswordResetPostOkResponse = EPInterfaces.PasswordResetPostOkResponse
+ResetPasswordUsingTokenInvalidTokenErrorResult = EPInterfaces.ResetPasswordUsingTokenInvalidTokenErrorResult
+ResetPasswordUsingTokenOkResult = EPInterfaces.ResetPasswordUsingTokenOkResult
+SignInPostWrongCredentialsErrorResponse = EPInterfaces.SignInPostWrongCredentialsErrorResponse
+SignInWrongCredentialsErrorResult = EPInterfaces.SignInWrongCredentialsErrorResult
+SignUpEmailAlreadyExistsErrorResult = EPInterfaces.SignUpEmailAlreadyExistsErrorResult
+SignUpPostEmailAlreadyExistsErrorResponse = EPInterfaces.SignUpPostEmailAlreadyExistsErrorResponse
+UpdateEmailOrPasswordEmailAlreadyExistsErrorResult = EPInterfaces.UpdateEmailOrPasswordEmailAlreadyExistsErrorResult
+UpdateEmailOrPasswordOkResult = EPInterfaces.UpdateEmailOrPasswordOkResult
+UpdateEmailOrPasswordUnknownUserIdErrorResult = EPInterfaces.UpdateEmailOrPasswordUnknownUserIdErrorResult
+
+AuthorisationUrlGetOkResponse = ThirdPartyInterfaces.AuthorisationUrlGetOkResponse
+SignInUpFieldErrorResult = ThirdPartyInterfaces.SignInUpFieldErrorResult
+SignInUpPostNoEmailGivenByProviderResponse = ThirdPartyInterfaces.SignInUpPostNoEmailGivenByProviderResponse
+SignInUpPostFieldErrorResponse = ThirdPartyInterfaces.SignInUpPostFieldErrorResponse
 
 
 class ThirdPartySignInUpOkResult():
@@ -103,7 +111,7 @@ class ThirdPartySignInUpPostOkResponse(APIResponse):
 
     def to_json(self) -> Dict[str, Any]:
         if self.user.third_party_info is None:
-            raise Exception("Third Party info cannot be None")
+            raise Exception("Third Party Info cannot be None")
 
         return {
             'status': self.status,

--- a/supertokens_python/recipe/thirdpartyemailpassword/recipeimplementation/implementation.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/recipeimplementation/implementation.py
@@ -35,14 +35,14 @@ from ..interfaces import (
     CreateResetPasswordWrongUserIdErrorResult,
     ResetPasswordUsingTokenOkResult,
     ResetPasswordUsingTokenInvalidTokenErrorResult,
-    SignInWrongCredentialsErrorResult,
-    SignUpEmailAlreadyExistsErrorResult,
+    EmailPasswordSignInWrongCredentialsErrorResult,
+    EmailPasswordSignUpEmailAlreadyExistsErrorResult,
     UpdateEmailOrPasswordEmailAlreadyExistsErrorResult,
     UpdateEmailOrPasswordOkResult,
     UpdateEmailOrPasswordUnknownUserIdErrorResult,
 
     ThirdPartySignInUpOkResult,
-    SignInUpFieldErrorResult)
+    ThirdPartySignInUpFieldErrorResult)
 from ..types import User
 from .email_password_recipe_implementation import \
     RecipeImplementation as DerivedEmailPasswordImplementation
@@ -134,7 +134,7 @@ class RecipeImplementation(RecipeInterface):
         return User(user_id=tp_user.user_id, email=tp_user.email, time_joined=tp_user.time_joined, third_party_info=tp_user.third_party_info)
 
     async def thirdparty_sign_in_up(self, third_party_id: str, third_party_user_id: str, email: str,
-                                    email_verified: bool, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpOkResult, SignInUpFieldErrorResult]:
+                                    email_verified: bool, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpOkResult, ThirdPartySignInUpFieldErrorResult]:
         if self.tp_sign_in_up is None:
             raise Exception("No thirdparty provider configured")
         result = await self.tp_sign_in_up(third_party_id, third_party_user_id, email, email_verified, user_context)
@@ -145,14 +145,14 @@ class RecipeImplementation(RecipeInterface):
             )
         return result
 
-    async def emailpassword_sign_in(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInOkResult, SignInWrongCredentialsErrorResult]:
+    async def emailpassword_sign_in(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInOkResult, EmailPasswordSignInWrongCredentialsErrorResult]:
         result = await self.ep_sign_in(email, password, user_context)
         if isinstance(result, EPInterfaces.SignInOkResult):
             return EmailPasswordSignInOkResult(
                 User(result.user.user_id, result.user.email, result.user.time_joined, None))
         return result
 
-    async def emailpassword_sign_up(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpOkResult, SignUpEmailAlreadyExistsErrorResult]:
+    async def emailpassword_sign_up(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpOkResult, EmailPasswordSignUpEmailAlreadyExistsErrorResult]:
         result = await self.ep_sign_up(email, password, user_context)
         if isinstance(result, EPInterfaces.SignUpOkResult):
             return EmailPasswordSignUpOkResult(

--- a/supertokens_python/recipe/thirdpartyemailpassword/recipeimplementation/implementation.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/recipeimplementation/implementation.py
@@ -15,18 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
-from supertokens_python.recipe.emailpassword.interfaces import (
-    CreateResetPasswordOkResult, CreateResetPasswordWrongUserIdErrorResult,
-    ResetPasswordUsingTokenOkResult,
-    ResetPasswordUsingTokenInvalidTokenErrorResult,
-    SignInOkResult, SignUpOkResult,
-    SignInWrongCredentialsErrorResult, SignUpEmailAlreadyExistsErrorResult,
-    UpdateEmailOrPasswordEmailAlreadyExistsErrorResult,
-    UpdateEmailOrPasswordOkResult,
-    UpdateEmailOrPasswordUnknownUserIdErrorResult)
-
-from ...thirdparty.interfaces import (
-    SignInUpFieldErrorResult, SignInUpOkResult)
+import supertokens_python.recipe.emailpassword.interfaces as EPInterfaces
+import supertokens_python.recipe.thirdparty.interfaces as ThirdPartyInterfaces
 
 if TYPE_CHECKING:
     from supertokens_python.querier import Querier
@@ -37,7 +27,22 @@ from supertokens_python.recipe.thirdparty.recipe_implementation import \
     RecipeImplementation as ThirdPartyImplementation
 
 from ..interfaces import (
-    RecipeInterface, EmailPasswordSignUpOkResult, EmailPasswordSignInOkResult, ThirdPartySignInUpOkResult)
+    RecipeInterface,
+
+    EmailPasswordSignUpOkResult,
+    EmailPasswordSignInOkResult,
+    CreateResetPasswordOkResult,
+    CreateResetPasswordWrongUserIdErrorResult,
+    ResetPasswordUsingTokenOkResult,
+    ResetPasswordUsingTokenInvalidTokenErrorResult,
+    SignInWrongCredentialsErrorResult,
+    SignUpEmailAlreadyExistsErrorResult,
+    UpdateEmailOrPasswordEmailAlreadyExistsErrorResult,
+    UpdateEmailOrPasswordOkResult,
+    UpdateEmailOrPasswordUnknownUserIdErrorResult,
+
+    ThirdPartySignInUpOkResult,
+    SignInUpFieldErrorResult)
 from ..types import User
 from .email_password_recipe_implementation import \
     RecipeImplementation as DerivedEmailPasswordImplementation
@@ -133,7 +138,7 @@ class RecipeImplementation(RecipeInterface):
         if self.tp_sign_in_up is None:
             raise Exception("No thirdparty provider configured")
         result = await self.tp_sign_in_up(third_party_id, third_party_user_id, email, email_verified, user_context)
-        if isinstance(result, SignInUpOkResult):
+        if isinstance(result, ThirdPartyInterfaces.SignInUpOkResult):
             return ThirdPartySignInUpOkResult(
                 User(result.user.user_id, result.user.email, result.user.time_joined, result.user.third_party_info),
                 result.created_new_user
@@ -142,14 +147,14 @@ class RecipeImplementation(RecipeInterface):
 
     async def emailpassword_sign_in(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignInOkResult, SignInWrongCredentialsErrorResult]:
         result = await self.ep_sign_in(email, password, user_context)
-        if isinstance(result, SignInOkResult):
+        if isinstance(result, EPInterfaces.SignInOkResult):
             return EmailPasswordSignInOkResult(
                 User(result.user.user_id, result.user.email, result.user.time_joined, None))
         return result
 
     async def emailpassword_sign_up(self, email: str, password: str, user_context: Dict[str, Any]) -> Union[EmailPasswordSignUpOkResult, SignUpEmailAlreadyExistsErrorResult]:
         result = await self.ep_sign_up(email, password, user_context)
-        if isinstance(result, SignUpOkResult):
+        if isinstance(result, EPInterfaces.SignUpOkResult):
             return EmailPasswordSignUpOkResult(
                 User(result.user.user_id, result.user.email, result.user.time_joined, None))
         return result

--- a/supertokens_python/recipe/thirdpartyemailpassword/syncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/syncio/__init__.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Union
 
 from supertokens_python.async_to_sync_wrapper import sync
 
-from ..interfaces import EmailPasswordSignInOkResult, SignInWrongCredentialsErrorResult
+from ..interfaces import EmailPasswordSignInOkResult, EmailPasswordSignInWrongCredentialsErrorResult
 from ..types import User
 
 
@@ -79,7 +79,7 @@ def reset_password_using_token(
     return sync(reset_password_using_token(token, new_password, user_context))
 
 
-def emailpassword_sign_in(email: str, password: str, user_context: Union[None, Dict[str, Any]] = None) -> Union[EmailPasswordSignInOkResult, SignInWrongCredentialsErrorResult]:
+def emailpassword_sign_in(email: str, password: str, user_context: Union[None, Dict[str, Any]] = None) -> Union[EmailPasswordSignInOkResult, EmailPasswordSignInWrongCredentialsErrorResult]:
     from supertokens_python.recipe.thirdpartyemailpassword.asyncio import \
         emailpassword_sign_in
     return sync(emailpassword_sign_in(email, password, user_context))

--- a/supertokens_python/recipe/thirdpartypasswordless/api/implementation.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/api/implementation.py
@@ -34,16 +34,16 @@ from ..interfaces import (
     ConsumeCodePostIncorrectUserInputCodeErrorResponse,
     CreateCodePostOkResponse,
     CreateCodePostGeneralErrorResponse,
-    EmailExistsGetOkResponse,
-    PhoneNumberExistsGetOkResponse,
+    PasswordlessEmailExistsGetOkResponse,
+    PasswordlessPhoneNumberExistsGetOkResponse,
     ConsumeCodePostRestartFlowErrorResponse,
     ResendCodePostOkResponse,
     ResendCodePostRestartFlowErrorResponse,
     ResendCodePostGeneralErrorResponse,
     AuthorisationUrlGetOkResponse,
     ThirdPartySignInUpPostOkResponse,
-    SignInUpPostNoEmailGivenByProviderResponse,
-    SignInUpPostFieldErrorResponse
+    ThirdPartySignInUpPostNoEmailGivenByProviderResponse,
+    ThirdPartySignInUpPostFieldErrorResponse
 )
 from ..types import User
 
@@ -83,7 +83,7 @@ class APIImplementation(APIInterface):
         return await self.tp_authorisation_url_get(provider, api_options, user_context)
 
     async def thirdparty_sign_in_up_post(self, provider: Provider, code: str, redirect_uri: str, client_id: Union[str, None], auth_code_response: Union[Dict[str, Any], None],
-                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse]:
+                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, ThirdPartySignInUpPostNoEmailGivenByProviderResponse, ThirdPartySignInUpPostFieldErrorResponse]:
         result = await self.tp_sign_in_up_post(provider, code, redirect_uri, client_id, auth_code_response, api_options, user_context)
         if isinstance(result, ThirdPartyInterfaces.SignInUpPostOkResponse):
             return ThirdPartySignInUpPostOkResponse(
@@ -131,11 +131,11 @@ class APIImplementation(APIInterface):
     async def passwordless_user_email_exists_get(self,
                                                  email: str,
                                                  api_options: PasswordlessAPIOptions,
-                                                 user_context: Dict[str, Any]) -> EmailExistsGetOkResponse:
+                                                 user_context: Dict[str, Any]) -> PasswordlessEmailExistsGetOkResponse:
         return await self.passwordless_user_email_exists_get(email, api_options, user_context)
 
     async def passwordless_user_phone_number_exists_get(self,
                                                         phone_number: str,
                                                         api_options: PasswordlessAPIOptions,
-                                                        user_context: Dict[str, Any]) -> PhoneNumberExistsGetOkResponse:
+                                                        user_context: Dict[str, Any]) -> PasswordlessPhoneNumberExistsGetOkResponse:
         return await self.passwordless_user_phone_number_exists_get(phone_number, api_options, user_context)

--- a/supertokens_python/recipe/thirdpartypasswordless/asyncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/asyncio/__init__.py
@@ -121,7 +121,7 @@ async def get_user_by_phone_number(phone_number: str, user_context: Union[None, 
 async def update_passwordless_user(user_id: str,
                                    email: Union[str, None] = None,
                                    phone_number: Union[str, None] = None,
-                                   user_context: Union[None, Dict[str, Any]] = None) -> Union[interfaces.UpdateUserOkResult, interfaces.UpdateUserUnknownUserIdErrorResult, interfaces.UpdateUserEmailAlreadyExistsErrorResult, interfaces.UpdateUserPhoneNumberAlreadyExistsErrorResult]:
+                                   user_context: Union[None, Dict[str, Any]] = None) -> Union[interfaces.PasswordlessUpdateUserOkResult, interfaces.PasswordlessUpdateUserUnknownUserIdErrorResult, interfaces.PasswordlessUpdateUserEmailAlreadyExistsErrorResult, interfaces.PasswordlessUpdateUserPhoneNumberAlreadyExistsErrorResult]:
     if user_context is None:
         user_context = {}
     return await ThirdPartyPasswordlessRecipe.get_instance().recipe_implementation.update_passwordless_user(user_id=user_id, email=email, phone_number=phone_number, user_context=user_context)

--- a/supertokens_python/recipe/thirdpartypasswordless/interfaces.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/interfaces.py
@@ -4,9 +4,6 @@ from supertokens_python.recipe.session import SessionContainer
 
 from supertokens_python.recipe.thirdparty import \
     interfaces as ThirdPartyInterfaces
-from supertokens_python.recipe.thirdparty.interfaces import (
-    AuthorisationUrlGetOkResponse, SignInUpFieldErrorResult, SignInUpOkResult,
-    SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse)
 from supertokens_python.recipe.thirdparty.provider import Provider
 from supertokens_python.types import APIResponse
 
@@ -34,8 +31,8 @@ CreateNewCodeForDeviceUserInputCodeAlreadyUsedErrorResult = PlessInterfaces.Crea
 DeleteUserInfoOkResult = PlessInterfaces.DeleteUserInfoOkResult
 DeleteUserInfoUnknownUserIdErrorResult = PlessInterfaces.DeleteUserInfoUnknownUserIdErrorResult
 DeviceType = PlessInterfaces.DeviceType
-EmailExistsGetOkResponse = PlessInterfaces.EmailExistsGetOkResponse
-PhoneNumberExistsGetOkResponse = PlessInterfaces.PhoneNumberExistsGetOkResponse
+PasswordlessEmailExistsGetOkResponse = PlessInterfaces.EmailExistsGetOkResponse
+PasswordlessPhoneNumberExistsGetOkResponse = PlessInterfaces.PhoneNumberExistsGetOkResponse
 ResendCodePostOkResponse = PlessInterfaces.ResendCodePostOkResponse
 ResendCodePostRestartFlowErrorResponse = PlessInterfaces.ResendCodePostRestartFlowErrorResponse
 ResendCodePostGeneralErrorResponse = PlessInterfaces.ResendCodePostGeneralErrorResponse
@@ -45,6 +42,12 @@ UpdateUserEmailAlreadyExistsErrorResult = PlessInterfaces.UpdateUserEmailAlready
 UpdateUserOkResult = PlessInterfaces.UpdateUserOkResult
 UpdateUserPhoneNumberAlreadyExistsErrorResult = PlessInterfaces.UpdateUserPhoneNumberAlreadyExistsErrorResult
 UpdateUserUnknownUserIdErrorResult = PlessInterfaces.UpdateUserUnknownUserIdErrorResult
+
+AuthorisationUrlGetOkResponse = ThirdPartyInterfaces.AuthorisationUrlGetOkResponse
+ThirdPartySignInUpFieldErrorResult = ThirdPartyInterfaces.SignInUpFieldErrorResult
+ThirdPartySignInUpOkResult = ThirdPartyInterfaces.SignInUpOkResult
+ThirdPartySignInUpPostNoEmailGivenByProviderResponse = ThirdPartyInterfaces.SignInUpPostNoEmailGivenByProviderResponse
+ThirdPartySignInUpPostFieldErrorResponse = ThirdPartyInterfaces.SignInUpPostFieldErrorResponse
 
 
 class ConsumeCodeOkResult():
@@ -76,7 +79,7 @@ class RecipeInterface(ABC):
 
     @abstractmethod
     async def thirdparty_sign_in_up(self, third_party_id: str, third_party_user_id: str, email: str,
-                                    email_verified: bool, user_context: Dict[str, Any]) -> Union[SignInUpOkResult, SignInUpFieldErrorResult]:
+                                    email_verified: bool, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpOkResult, ThirdPartySignInUpFieldErrorResult]:
         pass
 
     @abstractmethod
@@ -221,7 +224,7 @@ class APIInterface(ABC):
 
     @abstractmethod
     async def thirdparty_sign_in_up_post(self, provider: Provider, code: str, redirect_uri: str, client_id: Union[str, None], auth_code_response: Union[Dict[str, Any], None],
-                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse]:
+                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, ThirdPartySignInUpPostNoEmailGivenByProviderResponse, ThirdPartySignInUpPostFieldErrorResponse]:
         pass
 
     @abstractmethod
@@ -259,12 +262,12 @@ class APIInterface(ABC):
     async def passwordless_user_email_exists_get(self,
                                                  email: str,
                                                  api_options: PasswordlessAPIOptions,
-                                                 user_context: Dict[str, Any]) -> EmailExistsGetOkResponse:
+                                                 user_context: Dict[str, Any]) -> PasswordlessEmailExistsGetOkResponse:
         pass
 
     @abstractmethod
     async def passwordless_user_phone_number_exists_get(self,
                                                         phone_number: str,
                                                         api_options: PasswordlessAPIOptions,
-                                                        user_context: Dict[str, Any]) -> PhoneNumberExistsGetOkResponse:
+                                                        user_context: Dict[str, Any]) -> PasswordlessPhoneNumberExistsGetOkResponse:
         pass

--- a/supertokens_python/recipe/thirdpartypasswordless/interfaces.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/interfaces.py
@@ -6,35 +6,45 @@ from supertokens_python.recipe.thirdparty import \
     interfaces as ThirdPartyInterfaces
 from supertokens_python.recipe.thirdparty.interfaces import (
     AuthorisationUrlGetOkResponse, SignInUpFieldErrorResult, SignInUpOkResult,
-    SignInUpPostOkResponse, SignInUpPostNoEmailGivenByProviderResponse,
-    SignInUpPostFieldErrorResponse)
+    SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse)
 from supertokens_python.recipe.thirdparty.provider import Provider
 from supertokens_python.types import APIResponse
 
 from ..passwordless import interfaces as PlessInterfaces
-from ..passwordless.interfaces import (
-    ConsumeCodePostRestartFlowErrorResponse,
-    ConsumeCodePostGeneralErrorResponse, ConsumeCodePostIncorrectUserInputCodeErrorResponse,
-    ConsumeCodePostExpiredUserInputCodeErrorResponse,
-    ConsumeCodeExpiredUserInputCodeErrorResult,
-    ConsumeCodeIncorrectUserInputCodeErrorResult,
-    ConsumeCodeRestartFlowErrorResult, CreateCodeOkResult,
-    CreateCodePostOkResponse, CreateCodePostGeneralErrorResponse,
-    CreateNewCodeForDeviceOkResult,
-    CreateNewCodeForDeviceRestartFlowErrorResult,
-    CreateNewCodeForDeviceUserInputCodeAlreadyUsedErrorResult,
-    DeleteUserInfoOkResult, DeleteUserInfoUnknownUserIdErrorResult,
-    DeviceType, EmailExistsGetOkResponse, PhoneNumberExistsGetOkResponse,
-    ResendCodePostOkResponse, ResendCodePostRestartFlowErrorResponse,
-    ResendCodePostGeneralErrorResponse,
-    RevokeAllCodesOkResult, RevokeCodeOkResult,
-    UpdateUserEmailAlreadyExistsErrorResult, UpdateUserOkResult,
-    UpdateUserPhoneNumberAlreadyExistsErrorResult,
-    UpdateUserUnknownUserIdErrorResult)
+
 from .types import User
 
+# Export re-used classes
 ThirdPartyAPIOptions = ThirdPartyInterfaces.APIOptions
 PasswordlessAPIOptions = PlessInterfaces.APIOptions
+
+ConsumeCodePostRestartFlowErrorResponse = PlessInterfaces.ConsumeCodePostRestartFlowErrorResponse
+ConsumeCodePostGeneralErrorResponse = PlessInterfaces.ConsumeCodePostGeneralErrorResponse
+ConsumeCodePostIncorrectUserInputCodeErrorResponse = PlessInterfaces.ConsumeCodePostIncorrectUserInputCodeErrorResponse
+ConsumeCodePostExpiredUserInputCodeErrorResponse = PlessInterfaces.ConsumeCodePostExpiredUserInputCodeErrorResponse
+ConsumeCodeExpiredUserInputCodeErrorResult = PlessInterfaces.ConsumeCodeExpiredUserInputCodeErrorResult
+ConsumeCodeIncorrectUserInputCodeErrorResult = PlessInterfaces.ConsumeCodeIncorrectUserInputCodeErrorResult
+ConsumeCodeRestartFlowErrorResult = PlessInterfaces.ConsumeCodeRestartFlowErrorResult
+CreateCodeOkResult = PlessInterfaces.CreateCodeOkResult
+CreateCodePostOkResponse = PlessInterfaces.CreateCodePostOkResponse
+CreateCodePostGeneralErrorResponse = PlessInterfaces.CreateCodePostGeneralErrorResponse
+CreateNewCodeForDeviceOkResult = PlessInterfaces.CreateNewCodeForDeviceOkResult
+CreateNewCodeForDeviceRestartFlowErrorResult = PlessInterfaces.CreateNewCodeForDeviceRestartFlowErrorResult
+CreateNewCodeForDeviceUserInputCodeAlreadyUsedErrorResult = PlessInterfaces.CreateNewCodeForDeviceUserInputCodeAlreadyUsedErrorResult
+DeleteUserInfoOkResult = PlessInterfaces.DeleteUserInfoOkResult
+DeleteUserInfoUnknownUserIdErrorResult = PlessInterfaces.DeleteUserInfoUnknownUserIdErrorResult
+DeviceType = PlessInterfaces.DeviceType
+EmailExistsGetOkResponse = PlessInterfaces.EmailExistsGetOkResponse
+PhoneNumberExistsGetOkResponse = PlessInterfaces.PhoneNumberExistsGetOkResponse
+ResendCodePostOkResponse = PlessInterfaces.ResendCodePostOkResponse
+ResendCodePostRestartFlowErrorResponse = PlessInterfaces.ResendCodePostRestartFlowErrorResponse
+ResendCodePostGeneralErrorResponse = PlessInterfaces.ResendCodePostGeneralErrorResponse
+RevokeAllCodesOkResult = PlessInterfaces.RevokeAllCodesOkResult
+RevokeCodeOkResult = PlessInterfaces.RevokeCodeOkResult
+UpdateUserEmailAlreadyExistsErrorResult = PlessInterfaces.UpdateUserEmailAlreadyExistsErrorResult
+UpdateUserOkResult = PlessInterfaces.UpdateUserOkResult
+UpdateUserPhoneNumberAlreadyExistsErrorResult = PlessInterfaces.UpdateUserPhoneNumberAlreadyExistsErrorResult
+UpdateUserUnknownUserIdErrorResult = PlessInterfaces.UpdateUserUnknownUserIdErrorResult
 
 
 class ConsumeCodeOkResult():
@@ -163,6 +173,36 @@ class ConsumeCodePostOkResponse(APIResponse):
         }
 
 
+class ThirdPartySignInUpPostOkResponse(APIResponse):
+    status: str = 'OK'
+
+    def __init__(self, user: User, created_new_user: bool,
+                 auth_code_response: Dict[str, Any],
+                 session: SessionContainer):
+        self.user = user
+        self.created_new_user = created_new_user
+        self.auth_code_response = auth_code_response
+        self.session = session
+
+    def to_json(self) -> Dict[str, Any]:
+        if self.user.third_party_info is None:
+            raise ValueError('Third Party Info cannot be None')
+
+        return {
+            'status': self.status,
+            'user': {
+                'id': self.user.user_id,
+                'email': self.user.email,
+                'timeJoined': self.user.time_joined,
+                'thirdParty': {
+                    'id': self.user.third_party_info.id,
+                    'userId': self.user.third_party_info.user_id
+                }
+            },
+            'createdNewUser': self.created_new_user
+        }
+
+
 class APIInterface(ABC):
     def __init__(self):
         self.disable_thirdparty_sign_in_up_post = False
@@ -181,7 +221,7 @@ class APIInterface(ABC):
 
     @abstractmethod
     async def thirdparty_sign_in_up_post(self, provider: Provider, code: str, redirect_uri: str, client_id: Union[str, None], auth_code_response: Union[Dict[str, Any], None],
-                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[SignInUpPostOkResponse, SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse]:
+                                         api_options: ThirdPartyAPIOptions, user_context: Dict[str, Any]) -> Union[ThirdPartySignInUpPostOkResponse, SignInUpPostNoEmailGivenByProviderResponse, SignInUpPostFieldErrorResponse]:
         pass
 
     @abstractmethod

--- a/supertokens_python/recipe/thirdpartypasswordless/interfaces.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/interfaces.py
@@ -28,8 +28,8 @@ CreateCodePostGeneralErrorResponse = PlessInterfaces.CreateCodePostGeneralErrorR
 CreateNewCodeForDeviceOkResult = PlessInterfaces.CreateNewCodeForDeviceOkResult
 CreateNewCodeForDeviceRestartFlowErrorResult = PlessInterfaces.CreateNewCodeForDeviceRestartFlowErrorResult
 CreateNewCodeForDeviceUserInputCodeAlreadyUsedErrorResult = PlessInterfaces.CreateNewCodeForDeviceUserInputCodeAlreadyUsedErrorResult
-DeleteUserInfoOkResult = PlessInterfaces.DeleteUserInfoOkResult
-DeleteUserInfoUnknownUserIdErrorResult = PlessInterfaces.DeleteUserInfoUnknownUserIdErrorResult
+PasswordlessDeleteUserInfoOkResult = PlessInterfaces.DeleteUserInfoOkResult
+PasswordlessDeleteUserInfoUnknownUserIdErrorResult = PlessInterfaces.DeleteUserInfoUnknownUserIdErrorResult
 DeviceType = PlessInterfaces.DeviceType
 PasswordlessEmailExistsGetOkResponse = PlessInterfaces.EmailExistsGetOkResponse
 PasswordlessPhoneNumberExistsGetOkResponse = PlessInterfaces.PhoneNumberExistsGetOkResponse
@@ -38,10 +38,10 @@ ResendCodePostRestartFlowErrorResponse = PlessInterfaces.ResendCodePostRestartFl
 ResendCodePostGeneralErrorResponse = PlessInterfaces.ResendCodePostGeneralErrorResponse
 RevokeAllCodesOkResult = PlessInterfaces.RevokeAllCodesOkResult
 RevokeCodeOkResult = PlessInterfaces.RevokeCodeOkResult
-UpdateUserEmailAlreadyExistsErrorResult = PlessInterfaces.UpdateUserEmailAlreadyExistsErrorResult
-UpdateUserOkResult = PlessInterfaces.UpdateUserOkResult
-UpdateUserPhoneNumberAlreadyExistsErrorResult = PlessInterfaces.UpdateUserPhoneNumberAlreadyExistsErrorResult
-UpdateUserUnknownUserIdErrorResult = PlessInterfaces.UpdateUserUnknownUserIdErrorResult
+PasswordlessUpdateUserEmailAlreadyExistsErrorResult = PlessInterfaces.UpdateUserEmailAlreadyExistsErrorResult
+PasswordlessUpdateUserOkResult = PlessInterfaces.UpdateUserOkResult
+PasswordlessUpdateUserPhoneNumberAlreadyExistsErrorResult = PlessInterfaces.UpdateUserPhoneNumberAlreadyExistsErrorResult
+PasswordlessUpdateUserUnknownUserIdErrorResult = PlessInterfaces.UpdateUserUnknownUserIdErrorResult
 
 AuthorisationUrlGetOkResponse = ThirdPartyInterfaces.AuthorisationUrlGetOkResponse
 ThirdPartySignInUpFieldErrorResult = ThirdPartyInterfaces.SignInUpFieldErrorResult
@@ -108,15 +108,15 @@ class RecipeInterface(ABC):
 
     @abstractmethod
     async def update_passwordless_user(self, user_id: str,
-                                       email: Union[str, None], phone_number: Union[str, None], user_context: Dict[str, Any]) -> Union[UpdateUserOkResult, UpdateUserUnknownUserIdErrorResult, UpdateUserEmailAlreadyExistsErrorResult, UpdateUserPhoneNumberAlreadyExistsErrorResult]:
+                                       email: Union[str, None], phone_number: Union[str, None], user_context: Dict[str, Any]) -> Union[PasswordlessUpdateUserOkResult, PasswordlessUpdateUserUnknownUserIdErrorResult, PasswordlessUpdateUserEmailAlreadyExistsErrorResult, PasswordlessUpdateUserPhoneNumberAlreadyExistsErrorResult]:
         pass
 
     @abstractmethod
-    async def delete_email_for_passwordless_user(self, user_id: str, user_context: Dict[str, Any]) -> Union[DeleteUserInfoOkResult, DeleteUserInfoUnknownUserIdErrorResult]:
+    async def delete_email_for_passwordless_user(self, user_id: str, user_context: Dict[str, Any]) -> Union[PasswordlessDeleteUserInfoOkResult, PasswordlessDeleteUserInfoUnknownUserIdErrorResult]:
         pass
 
     @abstractmethod
-    async def delete_phone_number_for_user(self, user_id: str, user_context: Dict[str, Any]) -> Union[DeleteUserInfoOkResult, DeleteUserInfoUnknownUserIdErrorResult]:
+    async def delete_phone_number_for_user(self, user_id: str, user_context: Dict[str, Any]) -> Union[PasswordlessDeleteUserInfoOkResult, PasswordlessDeleteUserInfoUnknownUserIdErrorResult]:
         pass
 
     @abstractmethod

--- a/supertokens_python/recipe/thirdpartypasswordless/syncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/syncio/__init__.py
@@ -103,7 +103,7 @@ def get_user_by_phone_number(
 
 
 def update_passwordless_user(user_id: str, email: Union[str, None] = None,
-                             phone_number: Union[str, None] = None, user_context: Union[None, Dict[str, Any]] = None) -> Union[interfaces.UpdateUserOkResult, interfaces.UpdateUserUnknownUserIdErrorResult, interfaces.UpdateUserEmailAlreadyExistsErrorResult, interfaces.UpdateUserPhoneNumberAlreadyExistsErrorResult]:
+                             phone_number: Union[str, None] = None, user_context: Union[None, Dict[str, Any]] = None) -> Union[interfaces.PasswordlessUpdateUserOkResult, interfaces.PasswordlessUpdateUserUnknownUserIdErrorResult, interfaces.PasswordlessUpdateUserEmailAlreadyExistsErrorResult, interfaces.PasswordlessUpdateUserPhoneNumberAlreadyExistsErrorResult]:
     return sync(asyncio.update_passwordless_user(user_id=user_id, email=email,
                                                  phone_number=phone_number, user_context=user_context))
 


### PR DESCRIPTION
## Summary of change

Exporting re-used classes from `passwordless` interface and `thirdparty` interface in the `thirdpartypasswordless` interface. Also, cleaned up imports for code clarity.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2