### PR TITLE
refactor: added type checks for init params for session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds type checks to the parameters of the emailverification init funtion.
 - Adds type checks to the parameters of the jwt init funtion.
 - Adds type checks to the parameters of the openid init funtion.
+- Adds type checks to the parameters of the session init funtion.
 - Adds type checks to the parameters of the passwordless init funtion.
 
 ## [0.7.2] - 2022-05-08

--- a/supertokens_python/recipe/session/utils.py
+++ b/supertokens_python/recipe/session/utils.py
@@ -253,6 +253,18 @@ def validate_and_normalise_user_input(app_info: AppInfo,
                                                       None] = None,
                                       jwt: Union[JWTConfig, None] = None
                                       ):
+    if anti_csrf not in {"VIA_TOKEN", "VIA_CUSTOM_HEADER", "NONE", None}:
+        raise ValueError("anti_csrf must be one of VIA_TOKEN, VIA_CUSTOM_HEADER, NONE or None")
+
+    if error_handlers is not None and not isinstance(error_handlers, ErrorHandlers):  # type: ignore
+        raise ValueError("error_handlers must be an instance of ErrorHandlers or None")
+
+    if override is not None and not isinstance(override, InputOverrideConfig):  # type: ignore
+        raise ValueError("override must be an instance of InputOverrideConfig or None")
+
+    if jwt is not None and not isinstance(jwt, JWTConfig):  # type: ignore
+        raise ValueError("jwt must be an instance of JWTConfig or None")
+
     cookie_domain = normalise_session_scope(
         cookie_domain) if cookie_domain is not None else None
     top_level_api_domain = get_top_level_domain_for_same_site_resolution(

--- a/tests/input_validation/test_input_validation.py
+++ b/tests/input_validation/test_input_validation.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Dict, Any
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless
+from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless, session
 
 
 @pytest.mark.asyncio
@@ -273,3 +273,78 @@ async def test_init_validation_passwordless():
             ]
         )
     assert 'override must be of type OverrideConfig' == str(ex.value)
+
+
+@pytest.mark.asyncio
+async def test_init_validation_session():
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                session.init(
+                    anti_csrf='ABCDE'  # type: ignore
+                )
+            ]
+        )
+    assert 'anti_csrf must be one of VIA_TOKEN, VIA_CUSTOM_HEADER, NONE or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                session.init(
+                    error_handlers='error handlers'  # type: ignore
+                )
+            ]
+        )
+    assert 'error_handlers must be an instance of ErrorHandlers or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                session.init(
+                    override='override'  # type: ignore
+                )
+            ]
+        )
+    assert 'override must be an instance of InputOverrideConfig or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                session.init(
+                    jwt='jwt'  # type: ignore
+                )
+            ]
+        )
+    assert 'jwt must be an instance of JWTConfig or None' == str(ex.value)


### PR DESCRIPTION
## Summary of change

User might not have enabled linting with their IDE, might end up passing wrong types which is not caught early within the SDK. Added type checks for the session recipe.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2