### PR TITLE
refactor: added type checks for init params for thirdpartyemailpassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds type checks to the parameters of the session init funtion.
 - Adds type checks to the parameters of the passwordless init funtion.
 - Adds type checks to the parameters of the thirdparty init funtion.
+- Adds type checks to the parameters of the thirdpartyemailpassword init funtion.
 
 ## [0.7.2] - 2022-05-08
 - Bug fix in telemetry data API

--- a/supertokens_python/recipe/thirdpartyemailpassword/utils.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/utils.py
@@ -130,6 +130,25 @@ def validate_and_normalise_user_input(
         override: Union[InputOverrideConfig, None] = None,
         providers: Union[List[Provider], None] = None
 ) -> ThirdPartyEmailPasswordConfig:
+    if sign_up_feature is not None and not isinstance(sign_up_feature, InputSignUpFeature):  # type: ignore
+        raise ValueError('sign_up_feature must be of type InputSignUpFeature or None')
+
+    if reset_password_using_token_feature is not None and not isinstance(reset_password_using_token_feature, InputResetPasswordUsingTokenFeature):  # type: ignore
+        raise ValueError('reset_password_using_token_feature must be of type InputResetPasswordUsingTokenFeature or None')
+
+    if email_verification_feature is not None and not isinstance(email_verification_feature, InputEmailVerificationConfig):  # type: ignore
+        raise ValueError('email_verification_feature must be of type InputEmailVerificationConfig or None')
+
+    if override is not None and not isinstance(override, InputOverrideConfig):  # type: ignore
+        raise ValueError('override must be of type InputOverrideConfig or None')
+
+    if providers is not None and not isinstance(providers, List):  # type: ignore
+        raise ValueError('providers must be of type List[Provider] or None')
+
+    for provider in providers or []:
+        if not isinstance(provider, Provider):  # type: ignore
+            raise ValueError('providers must be of type List[Provider] or None')
+
     if providers is None:
         providers = []
     if override is None:

--- a/tests/input_validation/test_input_validation.py
+++ b/tests/input_validation/test_input_validation.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from typing import Dict, Any, List
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless, thirdparty
+from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless, thirdparty, thirdpartyemailpassword
 from supertokens_python.recipe.thirdparty.provider import Provider
 
 
@@ -329,3 +329,114 @@ async def test_init_validation_thirdparty():
             ]
         )
     assert 'override must be an instance of InputOverrideConfig or None' == str(ex.value)
+
+
+@pytest.mark.asyncio
+async def test_init_validation_thirdpartyemailpassword():
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdpartyemailpassword.init(
+                    sign_up_feature='sign up'  # type: ignore
+                )
+            ]
+        )
+    assert 'sign_up_feature must be of type InputSignUpFeature or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdpartyemailpassword.init(
+                    reset_password_using_token_feature='reset password'  # type: ignore
+                )
+            ]
+        )
+    assert 'reset_password_using_token_feature must be of type InputResetPasswordUsingTokenFeature or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdpartyemailpassword.init(
+                    email_verification_feature='email verification'  # type: ignore
+                )
+            ]
+        )
+    assert 'email_verification_feature must be of type InputEmailVerificationConfig or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdpartyemailpassword.init(
+                    override='override'  # type: ignore
+                )
+            ]
+        )
+    assert 'override must be of type InputOverrideConfig or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdpartyemailpassword.init(
+                    providers='providers'  # type: ignore
+                )
+            ]
+        )
+    assert 'providers must be of type List[Provider] or None' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdpartyemailpassword.init(
+                    providers=['providers']  # type: ignore
+                )
+            ]
+        )
+    assert 'providers must be of type List[Provider] or None' == str(ex.value)


### PR DESCRIPTION
## Summary of change

User might not have enabled linting with their IDE, might end up passing wrong types which is not caught early within the SDK. Added type checks for the thirdpartyemailpassword recipe.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2