### PR TITLE
refactor: added type checks for init params for thirdparty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds type checks to the parameters of the openid init funtion.
 - Adds type checks to the parameters of the session init funtion.
 - Adds type checks to the parameters of the passwordless init funtion.
+- Adds type checks to the parameters of the thirdparty init funtion.
 
 ## [0.7.2] - 2022-05-08
 - Bug fix in telemetry data API

--- a/supertokens_python/recipe/thirdparty/utils.py
+++ b/supertokens_python/recipe/thirdparty/utils.py
@@ -162,6 +162,12 @@ def validate_and_normalise_user_input(
         sign_in_and_up_feature: SignInAndUpFeature,
         email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
         override: Union[InputOverrideConfig, None] = None) -> ThirdPartyConfig:
+    if not isinstance(sign_in_and_up_feature, SignInAndUpFeature):  # type: ignore
+        raise ValueError('sign_in_and_up_feature must be an instance of SignInAndUpFeature')
+
+    if override is not None and not isinstance(override, InputOverrideConfig):  # type: ignore
+        raise ValueError('override must be an instance of InputOverrideConfig or None')
+
     if override is None:
         override = InputOverrideConfig()
     return ThirdPartyConfig(sign_in_and_up_feature, validate_and_normalise_email_verification_config(recipe, email_verification_feature, override),

--- a/tests/input_validation/test_input_validation.py
+++ b/tests/input_validation/test_input_validation.py
@@ -1,7 +1,9 @@
 import pytest
-from typing import Dict, Any
+import os
+from typing import Dict, Any, List
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless
+from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless, thirdparty
+from supertokens_python.recipe.thirdparty.provider import Provider
 
 
 @pytest.mark.asyncio
@@ -273,3 +275,57 @@ async def test_init_validation_passwordless():
             ]
         )
     assert 'override must be of type OverrideConfig' == str(ex.value)
+
+
+providers_list: List[Provider] = [
+    thirdparty.Google(
+        client_id=os.environ.get('GOOGLE_CLIENT_ID'),  # type: ignore
+        client_secret=os.environ.get('GOOGLE_CLIENT_SECRET')  # type: ignore
+    ), thirdparty.Facebook(
+        client_id=os.environ.get('FACEBOOK_CLIENT_ID'),  # type: ignore
+        client_secret=os.environ.get('FACEBOOK_CLIENT_SECRET')  # type: ignore
+    ), thirdparty.Github(
+        client_id=os.environ.get('GITHUB_CLIENT_ID'),  # type: ignore
+        client_secret=os.environ.get('GITHUB_CLIENT_SECRET')  # type: ignore
+    )
+]
+
+
+@pytest.mark.asyncio
+async def test_init_validation_thirdparty():
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdparty.init(
+                    sign_in_and_up_feature='sign in up'  # type: ignore
+                )
+            ]
+        )
+    assert 'sign_in_and_up_feature must be an instance of SignInAndUpFeature' == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                thirdparty.init(
+                    sign_in_and_up_feature=thirdparty.SignInAndUpFeature(providers_list),
+                    override='override'  # type: ignore
+                )
+            ]
+        )
+    assert 'override must be an instance of InputOverrideConfig or None' == str(ex.value)


### PR DESCRIPTION
## Summary of change

User might not have enabled linting with their IDE, might end up passing wrong types which is not caught early within the SDK. Added type checks for the thirdparty recipe.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2