### PR TITLE
fix: fixed execute_async to use real asyncio mode, handle send_telemetry exception silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+
+## [0.7.3] - 2022-05-12
 - Fixed execute_async to check and use asyncio mode.
 - Ignores any exception from send_telemetry, not to prevent the app from starting up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Fixed execute_async to check and use asyncio mode.
+- Ignores any exception from send_telemetry, not to prevent the app from starting up.
 
 ## [0.7.2] - 2022-05-08
 - Bug fix in telemetry data API

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.7.2",
+    version="0.7.3",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12', '2.13']
-VERSION = '0.7.2'
+VERSION = '0.7.3'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'

--- a/supertokens_python/logger.py
+++ b/supertokens_python/logger.py
@@ -64,7 +64,6 @@ _logger.addHandler(streamHandler)
 
 # Export logger.debug as log_debug_message function
 log_debug_message = _logger.debug
-log_warning_message = _logger.warning
 
 
 def get_maybe_none_as_str(o: Union[str, None]) -> str:

--- a/supertokens_python/logger.py
+++ b/supertokens_python/logger.py
@@ -64,6 +64,7 @@ _logger.addHandler(streamHandler)
 
 # Export logger.debug as log_debug_message function
 log_debug_message = _logger.debug
+log_warning_message = _logger.warning
 
 
 def get_maybe_none_as_str(o: Union[str, None]) -> str:

--- a/supertokens_python/supertokens.py
+++ b/supertokens_python/supertokens.py
@@ -196,7 +196,10 @@ class Supertokens:
                 environ['SUPERTOKENS_ENV'] != 'testing')
 
         if telemetry:
-            execute_async(self.app_info.mode, self.send_telemetry)
+            try:
+                execute_async(self.app_info.mode, self.send_telemetry)
+            except Exception:
+                pass  # Do not stop app startup if telemetry fails
 
     async def send_telemetry(self):
         # If telemetry is enabled manually and the app is running in testing mode,

--- a/supertokens_python/utils.py
+++ b/supertokens_python/utils.py
@@ -163,7 +163,7 @@ def execute_async(mode: str, func: Callable[[], Coroutine[Any, Any, None]]):
         real_mode = 'wsgi'
 
     if mode != real_mode:
-        warnings.warn('Inconsistent mode detected, check if you are using the right mode', category=RuntimeWarning)
+        warnings.warn('Inconsistent mode detected, check if you are using the right asgi / wsgi mode', category=RuntimeWarning)
 
     if real_mode == 'wsgi':
         asyncio.run(func())

--- a/supertokens_python/utils.py
+++ b/supertokens_python/utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from base64 import b64decode, b64encode
 from re import fullmatch
 from time import time
@@ -27,7 +28,7 @@ from supertokens_python.framework.fastapi.framework import FastapiFramework
 from supertokens_python.framework.flask.framework import FlaskFramework
 from supertokens_python.framework.request import BaseRequest
 from supertokens_python.framework.response import BaseResponse
-from supertokens_python.logger import log_debug_message, log_warning_message
+from supertokens_python.logger import log_debug_message
 
 from .constants import ERROR_MESSAGE_KEY, RID_KEY_HEADER
 from .exceptions import raise_general_exception
@@ -162,7 +163,7 @@ def execute_async(mode: str, func: Callable[[], Coroutine[Any, Any, None]]):
         real_mode = 'wsgi'
 
     if mode != real_mode:
-        log_warning_message('Inconsistent mode detected, check if you are using the right mode')
+        warnings.warn('Inconsistent mode detected, check if you are using the right mode', category=RuntimeWarning)
 
     if real_mode == 'wsgi':
         asyncio.run(func())


### PR DESCRIPTION

## Summary of change

fix as follows:
- wrapped send_telemetry around try-except so that it won’t stop the app startup
- inside execute_async, determine running loop and execute based on the running mode
- also in execute_async throw out a warning if mode inconsistency is seen

## Related issues

## Test Plan

Tested wrong and right modes with FastAPI, Flask and Django with both gunicorn (wsgi) and uvicorn (asgi). Ensured right warning is shown and app starts up correctly.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens_python/constants.py`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] ~~If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable~~
-   [ ] ~~If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py~~
 
## Remaining TODOs for this PR
