### PR TITLE
refactor: added type checks for init params for usermetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds type checks to the parameters of the thirdparty init funtion.
 - Adds type checks to the parameters of the thirdpartyemailpassword init funtion.
 - Adds type checks to the parameters of the thirdpartypasswordless init funtion.
+- Adds type checks to the parameters of the usermetadata init funtion.
 
 ## [0.7.2] - 2022-05-08
 - Bug fix in telemetry data API

--- a/supertokens_python/recipe/usermetadata/utils.py
+++ b/supertokens_python/recipe/usermetadata/utils.py
@@ -39,6 +39,9 @@ class UserMetadataConfig:
 
 def validate_and_normalise_user_input(_recipe: UserMetadataRecipe, _app_info: AppInfo,
                                       override: Union[InputOverrideConfig, None] = None) -> UserMetadataConfig:
+    if override is not None and not isinstance(override, InputOverrideConfig):  # type: ignore
+        raise ValueError('override must be an instance of InputOverrideConfig or None')
+
     if override is None:
         override = InputOverrideConfig()
 

--- a/tests/input_validation/test_input_validation.py
+++ b/tests/input_validation/test_input_validation.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from typing import Dict, Any, List
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless, session, thirdparty, thirdpartyemailpassword, thirdpartypasswordless
+from supertokens_python.recipe import emailpassword, emailverification, jwt, openid, passwordless, session, thirdparty, thirdpartyemailpassword, thirdpartypasswordless, usermetadata
 from supertokens_python.recipe.passwordless.utils import ContactEmailOrPhoneConfig
 from supertokens_python.recipe.thirdparty.provider import Provider
 
@@ -660,3 +660,24 @@ async def test_init_validation_thirdpartypasswordless():
             ]
         )
     assert 'providers must be of type List[Provider] or None' == str(ex.value)
+
+
+@pytest.mark.asyncio
+async def test_init_validation_usermetadata():
+    with pytest.raises(ValueError) as ex:
+        init(
+            supertokens_config=SupertokensConfig('http://localhost:3567'),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="http://api.supertokens.io",
+                website_domain="http://supertokens.io",
+                api_base_path="/auth"
+            ),
+            framework='fastapi',
+            recipe_list=[
+                usermetadata.init(
+                    override='override'  # type: ignore
+                )
+            ]
+        )
+    assert 'override must be an instance of InputOverrideConfig or None' == str(ex.value)


### PR DESCRIPTION
## Summary of change

User might not have enabled linting with their IDE, might end up passing wrong types which is not caught early within the SDK. Added type checks for the usermetadata recipe.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2