### PR TITLE
fix: startup supertokens process in test_mode

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -121,7 +121,7 @@ def start_st(host: str = 'localhost', port: str = '3567'):
     pid_after = pid_before = __get_list_of_process_ids()
     run('cd ' + INSTALLATION_PATH + ' && java -Djava.security.egd=file:/dev/urandom -classpath '
                                     '"./core/*:./plugin-interface/*" io.supertokens.Main ./ DEV host='
-        + host + ' port=' + str(port) + ' &', shell=True, stdout=DEVNULL)
+        + host + ' port=' + str(port) + ' test_mode &', shell=True, stdout=DEVNULL)
     for _ in range(35):
         pid_after = __get_list_of_process_ids()
         if len(pid_after) != len(pid_before):


### PR DESCRIPTION
## Summary of change

Similar to golang:
```
command := fmt.Sprintf(`java -Djava.security.egd=file:/dev/urandom -classpath "./core/*:./plugin-interface/*" io.supertokens.Main ./ DEV host=%s port=%s test_mode`, host, port)
```

## Related issues


## Test Plan


## Documentation changes


## Checklist for important updates

-   [ ] ~~Changelog has been updated~~
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens_python/constants.py`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] ~~Changes to the version if needed~~
    -   ~~In `setup.py`~~
    -   ~~In `supertokens_python/constants.py`~~
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] ~~If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable~~
-   [ ] ~~If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py~~
 
## Remaining TODOs for this PR
