### PR TITLE
fix: thirdpartypasswordless email verification fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   Changes `get_email_for_user_id` function inside thirdpartypasswordless to take into account passwordless emails and return an empty string in case a passwordless email doesn't exist. This helps situations where the dev wants to customise the email verification functions in the thirdpartypasswordless recipe.
+
 ## [0.8.4] - 2022-06-17
 ### Added
 

--- a/supertokens_python/recipe/thirdpartypasswordless/recipe.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/recipe.py
@@ -340,10 +340,13 @@ class ThirdPartyPasswordlessRecipe(RecipeModule):
         if user_info is None:
             raise Exception('Unknown User ID provided')
         if user_info.third_party_info is None:
-            # this is a passwordless user.. so we always return some random email,
-            # and in the function for isEmailVerified, we will check if the user
-            # is a passwordless user, and if they are, we will return true in there
-            return "_____supertokens_passwordless_user@supertokens.com"
+            if user_info.email is not None:
+                return user_info.email
+            # this is a passwordless user with only a phone number.
+            # returning an empty string here is not a problem since
+            # we override the email verification functions above to
+            # send that the email is already verified for passwordless users.
+            return ""
         if user_info.email is None:
             raise Exception("Should never come here")
         return user_info.email


### PR DESCRIPTION
## Summary of change

Changes `get_email_for_user_id ` in thirdpartypasswordless to take into account passwordless user email as well in case the dev wants to customise the thirdpartypasswordless recipe's email verification functions to take into account passwordless users as well.

## Related issues

-   https://discord.com/channels/603466164219281420/987701400433725440/988016274443489300