### PR TITLE
refactor: Remove <Recipe>(Email|SMS)TemplateVars in favour of (Email|SMS)TemplateVars to improve DX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Fixes Cookie same_site config validation.
+- Remove `<Recipe>(Email|SMS)TemplateVars` in favour of `(Email|SMS)TemplateVars` for better DX.
 
 ### Breaking change
 -   https://github.com/supertokens/supertokens-node/issues/220

--- a/supertokens_python/recipe/emailpassword/__init__.py
+++ b/supertokens_python/recipe/emailpassword/__init__.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Callable, Union
 from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryConfig
 from supertokens_python.recipe.emailpassword.types import \
-    EmailPasswordEmailTemplateVars
+    EmailTemplateVars
 
 from . import exceptions as ex
 from . import utils
@@ -44,7 +44,7 @@ def init(sign_up_feature: Union[utils.InputSignUpFeature, None] = None,
              utils.InputResetPasswordUsingTokenFeature, None] = None,
          email_verification_feature: Union[utils.InputEmailVerificationConfig, None] = None,
          override: Union[utils.InputOverrideConfig, None] = None,
-         email_delivery: Union[EmailDeliveryConfig[EmailPasswordEmailTemplateVars], None] = None
+         email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
          ) -> Callable[[AppInfo], RecipeModule]:
     return EmailPasswordRecipe.init(
         sign_up_feature,

--- a/supertokens_python/recipe/emailpassword/asyncio/__init__.py
+++ b/supertokens_python/recipe/emailpassword/asyncio/__init__.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Union
 
 from supertokens_python.recipe.emailpassword import EmailPasswordRecipe
 
-from ..types import EmailPasswordEmailTemplateVars, User
+from ..types import EmailTemplateVars, User
 
 
 async def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -100,7 +100,7 @@ async def revoke_email_verification_token(user_id: str, user_context: Union[None
         user_id, email, user_context)
 
 
-async def send_email(input_: EmailPasswordEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await EmailPasswordRecipe.get_instance().email_delivery.ingredient_interface_impl.send_email(input_, user_context)

--- a/supertokens_python/recipe/emailpassword/emaildelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/emailpassword/emaildelivery/services/backward_compatibility/__init__.py
@@ -21,13 +21,14 @@ from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryInterface
 from supertokens_python.logger import log_debug_message
 from supertokens_python.recipe.emailpassword.interfaces import (
-    RecipeInterface, EmailPasswordEmailTemplateVars)
-from supertokens_python.recipe.emailpassword.types import User
+    EmailTemplateVars, RecipeInterface)
+from supertokens_python.recipe.emailpassword.types import (
+    User, VerificationEmailTemplateVars)
 from supertokens_python.recipe.emailverification.emaildelivery.services.backward_compatibility import \
     BackwardCompatibilityService as \
     EmailVerificationBackwardCompatibilityService
 from supertokens_python.recipe.emailverification.types import \
-    User as EmailVerificationUser, VerificationEmailTemplateVars
+    User as EmailVerificationUser
 from supertokens_python.supertokens import AppInfo
 from supertokens_python.utils import handle_httpx_client_exceptions
 
@@ -58,7 +59,7 @@ def default_create_and_send_custom_email(
     return func
 
 
-class BackwardCompatibilityService(EmailDeliveryInterface[EmailPasswordEmailTemplateVars]):
+class BackwardCompatibilityService(EmailDeliveryInterface[EmailTemplateVars]):
     app_info: AppInfo
     ev_backward_compatibility_service: EmailVerificationBackwardCompatibilityService
 
@@ -98,7 +99,7 @@ class BackwardCompatibilityService(EmailDeliveryInterface[EmailPasswordEmailTemp
             app_info, create_and_send_custom_email=create_and_send_custom_email
         )
 
-    async def send_email(self, template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             await self.ev_backward_compatibility_service.send_email(template_vars, user_context)
         else:

--- a/supertokens_python/recipe/emailpassword/emaildelivery/services/smtp/__init__.py
+++ b/supertokens_python/recipe/emailpassword/emaildelivery/services/smtp/__init__.py
@@ -19,7 +19,7 @@ from supertokens_python.ingredients.emaildelivery.services.smtp import (
 from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryInterface, SMTPServiceInterface, SMTPSettings
 from supertokens_python.recipe.emailpassword.types import \
-    EmailPasswordEmailTemplateVars, SMTPOverrideInput
+    EmailTemplateVars, SMTPOverrideInput
 from supertokens_python.recipe.emailverification.emaildelivery.services.smtp import \
     SMTPService as EmailVerificationSMTPService
 from supertokens_python.recipe.emailverification.types import VerificationEmailTemplateVars
@@ -29,8 +29,8 @@ from .service_implementation.email_verification_implementation import \
     ServiceImplementation as EmailVerificationServiceImpl
 
 
-class SMTPService(EmailDeliveryInterface[EmailPasswordEmailTemplateVars]):
-    service_implementation: SMTPServiceInterface[EmailPasswordEmailTemplateVars]
+class SMTPService(EmailDeliveryInterface[EmailTemplateVars]):
+    service_implementation: SMTPServiceInterface[EmailTemplateVars]
 
     def __init__(self, smtp_settings: SMTPSettings,
                  override: Union[Callable[[SMTPOverrideInput], SMTPOverrideInput], None] = None) -> None:
@@ -44,7 +44,7 @@ class SMTPService(EmailDeliveryInterface[EmailPasswordEmailTemplateVars]):
             override=lambda _: EmailVerificationServiceImpl(self.service_implementation)
         )
 
-    async def send_email(self, template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             return await self.email_verification_smtp_service.send_email(template_vars, user_context)
 

--- a/supertokens_python/recipe/emailpassword/emaildelivery/services/smtp/service_implementation/__init__.py
+++ b/supertokens_python/recipe/emailpassword/emaildelivery/services/smtp/service_implementation/__init__.py
@@ -20,7 +20,7 @@ from supertokens_python.ingredients.emaildelivery.types import EmailContent, SMT
 from supertokens_python.recipe.emailpassword.emaildelivery.services.smtp.password_reset import \
     get_password_reset_email_content
 from supertokens_python.recipe.emailpassword.types import \
-    EmailPasswordEmailTemplateVars
+    EmailTemplateVars
 from supertokens_python.recipe.emailverification.emaildelivery.services.smtp.service_implementation import \
     ServiceImplementation as EVServiceImplementation
 from supertokens_python.recipe.emailverification.types import VerificationEmailTemplateVars
@@ -29,7 +29,7 @@ from .email_verification_implementation import \
     ServiceImplementation as DerivedEVServiceImplementation
 
 
-class ServiceImplementation(SMTPServiceInterface[EmailPasswordEmailTemplateVars]):
+class ServiceImplementation(SMTPServiceInterface[EmailTemplateVars]):
     def __init__(self, transporter: Transporter) -> None:
         super().__init__(transporter)
 
@@ -44,7 +44,7 @@ class ServiceImplementation(SMTPServiceInterface[EmailPasswordEmailTemplateVars]
     async def send_raw_email(self, content: EmailContent, user_context: Dict[str, Any]) -> None:
         await self.transporter.send_email(content, user_context)
 
-    async def get_content(self, template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]) -> EmailContent:
+    async def get_content(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> EmailContent:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             return await self.ev_get_content(template_vars, user_context)
         return get_password_reset_email_content(template_vars)

--- a/supertokens_python/recipe/emailpassword/emaildelivery/services/smtp/service_implementation/email_verification_implementation.py
+++ b/supertokens_python/recipe/emailpassword/emaildelivery/services/smtp/service_implementation/email_verification_implementation.py
@@ -16,12 +16,12 @@ from typing import Any, Dict
 
 from supertokens_python.ingredients.emaildelivery.types import EmailContent, SMTPServiceInterface
 from supertokens_python.recipe.emailpassword.types import (
-    EmailPasswordEmailTemplateVars)
+    EmailTemplateVars)
 from supertokens_python.recipe.emailverification.types import VerificationEmailTemplateVars
 
 
 class ServiceImplementation(SMTPServiceInterface[VerificationEmailTemplateVars]):
-    def __init__(self, email_password_service_implementation: SMTPServiceInterface[EmailPasswordEmailTemplateVars]) -> None:
+    def __init__(self, email_password_service_implementation: SMTPServiceInterface[EmailTemplateVars]) -> None:
         super().__init__(email_password_service_implementation.transporter)
         self.email_password_service_implementation = email_password_service_implementation
 

--- a/supertokens_python/recipe/emailpassword/interfaces.py
+++ b/supertokens_python/recipe/emailpassword/interfaces.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 from supertokens_python.ingredients.emaildelivery import \
     EmailDeliveryIngredient
 from supertokens_python.recipe.emailpassword.types import \
-    EmailPasswordEmailTemplateVars
+    EmailTemplateVars
 
 from ...types import APIResponse, GeneralErrorResponse
 from ..emailverification.interfaces import \
@@ -120,7 +120,7 @@ class APIOptions:
     def __init__(self, request: BaseRequest, response: BaseResponse, recipe_id: str,
                  config: EmailPasswordConfig, recipe_implementation: RecipeInterface,
                  email_verification_recipe_implementation: EmailVerificationRecipeInterface,
-                 email_delivery: EmailDeliveryIngredient[EmailPasswordEmailTemplateVars]):
+                 email_delivery: EmailDeliveryIngredient[EmailTemplateVars]):
         self.request: BaseRequest = request
         self.response: BaseResponse = response
         self.recipe_id: str = recipe_id

--- a/supertokens_python/recipe/emailpassword/recipe.py
+++ b/supertokens_python/recipe/emailpassword/recipe.py
@@ -22,7 +22,7 @@ from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryConfig
 from supertokens_python.normalised_url_path import NormalisedURLPath
 from supertokens_python.recipe.emailpassword.types import (
-    EmailPasswordIngredients, EmailPasswordEmailTemplateVars)
+    EmailPasswordIngredients, EmailTemplateVars)
 from supertokens_python.recipe.emailverification.types import \
     EmailVerificationIngredients, VerificationEmailTemplateVars
 from supertokens_python.recipe_module import APIHandled, RecipeModule
@@ -57,7 +57,7 @@ from .utils import (InputEmailVerificationConfig, InputOverrideConfig,
 class EmailPasswordRecipe(RecipeModule):
     recipe_id = 'emailpassword'
     __instance = None
-    email_delivery: EmailDeliveryIngredient[EmailPasswordEmailTemplateVars]
+    email_delivery: EmailDeliveryIngredient[EmailTemplateVars]
 
     def __init__(self, recipe_id: str, app_info: AppInfo,
                  ingredients: EmailPasswordIngredients,
@@ -66,7 +66,7 @@ class EmailPasswordRecipe(RecipeModule):
                  email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
                  override: Union[InputOverrideConfig, None] = None,
                  email_verification_recipe: Union[EmailVerificationRecipe, None] = None,
-                 email_delivery: Union[EmailDeliveryConfig[EmailPasswordEmailTemplateVars], None] = None,
+                 email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
                  ):
         super().__init__(recipe_id, app_info)
         self.config = validate_and_normalise_user_input(self, app_info, sign_up_feature,
@@ -159,7 +159,7 @@ class EmailPasswordRecipe(RecipeModule):
              reset_password_using_token_feature: Union[InputResetPasswordUsingTokenFeature, None] = None,
              email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
              override: Union[InputOverrideConfig, None] = None,
-             email_delivery: Union[EmailDeliveryConfig[EmailPasswordEmailTemplateVars], None] = None):
+             email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None):
         def func(app_info: AppInfo):
             if EmailPasswordRecipe.__instance is None:
                 ingredients = EmailPasswordIngredients(None)

--- a/supertokens_python/recipe/emailpassword/syncio/__init__.py
+++ b/supertokens_python/recipe/emailpassword/syncio/__init__.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Union
 from supertokens_python.async_to_sync_wrapper import sync
 
 from ..interfaces import SignInOkResult, SignInWrongCredentialsError
-from ..types import EmailPasswordEmailTemplateVars, User
+from ..types import EmailTemplateVars, User
 
 
 def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -90,6 +90,6 @@ def revoke_email_verification_token(user_id: str, user_context: Union[None, Dict
     return sync(revoke_email_verification_token(user_id, user_context))
 
 
-def send_email(input_: EmailPasswordEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     from supertokens_python.recipe.emailpassword.asyncio import send_email
     return sync(send_email(input_, user_context))

--- a/supertokens_python/recipe/emailpassword/types.py
+++ b/supertokens_python/recipe/emailpassword/types.py
@@ -81,13 +81,11 @@ class PasswordResetEmailTemplateVars:
         self.password_reset_link = password_reset_link
 
 
-EmailPasswordEmailTemplateVars = Union[
+# Export:
+EmailTemplateVars = Union[
     PasswordResetEmailTemplateVars,
     ev_types.VerificationEmailTemplateVars
 ]
-
-# Export:
-EmailTemplateVars = EmailPasswordEmailTemplateVars
 # PasswordResetEmailTemplateVars (Already exported because it's defined in the same)
 VerificationEmailTemplateVars = ev_types.VerificationEmailTemplateVars
 
@@ -98,6 +96,6 @@ EmailDeliveryOverrideInput = EmailDeliveryInterface[EmailTemplateVars]
 
 class EmailPasswordIngredients:
     def __init__(self,
-                 email_delivery: Union[EmailDeliveryIngredient[EmailPasswordEmailTemplateVars], None] = None
+                 email_delivery: Union[EmailDeliveryIngredient[EmailTemplateVars], None] = None
                  ) -> None:
         self.email_delivery = email_delivery

--- a/supertokens_python/recipe/emailpassword/utils.py
+++ b/supertokens_python/recipe/emailpassword/utils.py
@@ -24,7 +24,7 @@ from supertokens_python.recipe.emailpassword.emaildelivery.services.backward_com
 from ..emailverification.types import User as EmailVerificationUser
 from .interfaces import APIInterface, RecipeInterface
 from .types import (InputFormField, NormalisedFormField,
-                    EmailPasswordEmailTemplateVars, User)
+                    EmailTemplateVars, User)
 
 if TYPE_CHECKING:
     from .recipe import EmailPasswordRecipe
@@ -277,7 +277,7 @@ class EmailPasswordConfig:
                  reset_password_using_token_feature: ResetPasswordUsingTokenFeature,
                  email_verification_feature: ParentRecipeEmailVerificationConfig,
                  override: OverrideConfig,
-                 get_email_delivery_config: Callable[[RecipeInterface], EmailDeliveryConfigWithService[EmailPasswordEmailTemplateVars]]
+                 get_email_delivery_config: Callable[[RecipeInterface], EmailDeliveryConfigWithService[EmailTemplateVars]]
                  ):
         self.sign_up_feature = sign_up_feature
         self.sign_in_feature = sign_in_feature
@@ -294,7 +294,7 @@ def validate_and_normalise_user_input(recipe: EmailPasswordRecipe, app_info: App
                                           InputResetPasswordUsingTokenFeature, None] = None,
                                       email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
                                       override: Union[InputOverrideConfig, None] = None,
-                                      email_delivery: Union[EmailDeliveryConfig[EmailPasswordEmailTemplateVars], None] = None
+                                      email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
                                       ) -> EmailPasswordConfig:
 
     if sign_up_feature is not None and not isinstance(sign_up_feature, InputSignUpFeature):  # type: ignore
@@ -319,7 +319,7 @@ def validate_and_normalise_user_input(recipe: EmailPasswordRecipe, app_info: App
 
     def get_email_delivery_config(
         ep_recipe: RecipeInterface,
-    ) -> EmailDeliveryConfigWithService[EmailPasswordEmailTemplateVars]:
+    ) -> EmailDeliveryConfigWithService[EmailTemplateVars]:
         if email_delivery and email_delivery.service:
             return EmailDeliveryConfigWithService(
                 service=email_delivery.service,

--- a/supertokens_python/recipe/emailverification/asyncio/__init__.py
+++ b/supertokens_python/recipe/emailverification/asyncio/__init__.py
@@ -12,7 +12,7 @@
 # under the License.
 from typing import Any, Dict, Union
 
-from supertokens_python.recipe.emailverification.types import VerificationEmailTemplateVars
+from supertokens_python.recipe.emailverification.types import EmailTemplateVars
 from supertokens_python.recipe.emailverification.recipe import \
     EmailVerificationRecipe
 
@@ -47,7 +47,7 @@ async def revoke_email_verification_tokens(user_id: str, email: str, user_contex
     return await EmailVerificationRecipe.get_instance().recipe_implementation.revoke_email_verification_tokens(user_id, email, user_context)
 
 
-async def send_email(input_: VerificationEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await EmailVerificationRecipe.get_instance().email_delivery.ingredient_interface_impl.send_email(input_, user_context)

--- a/supertokens_python/recipe/emailverification/syncio/__init__.py
+++ b/supertokens_python/recipe/emailverification/syncio/__init__.py
@@ -15,7 +15,7 @@
 from typing import Any, Dict, Union
 
 from supertokens_python.async_to_sync_wrapper import sync
-from supertokens_python.recipe.emailverification.types import VerificationEmailTemplateVars
+from supertokens_python.recipe.emailverification.types import EmailTemplateVars
 
 
 def create_email_verification_token(
@@ -49,6 +49,6 @@ def revoke_email_verification_tokens(user_id: str, email: str, user_context: Uni
     return sync(revoke_email_verification_tokens(user_id, email, user_context))
 
 
-def send_email(input_: VerificationEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     from supertokens_python.recipe.emailverification.asyncio import send_email
     return sync(send_email(input_, user_context))

--- a/supertokens_python/recipe/emailverification/types.py
+++ b/supertokens_python/recipe/emailverification/types.py
@@ -53,5 +53,5 @@ EmailDeliveryOverrideInput = EmailDeliveryInterface[EmailTemplateVars]
 
 
 class EmailVerificationIngredients:
-    def __init__(self, email_delivery: Union[EmailDeliveryIngredient[VerificationEmailTemplateVars], None] = None):
+    def __init__(self, email_delivery: Union[EmailDeliveryIngredient[EmailTemplateVars], None] = None):
         self.email_delivery = email_delivery

--- a/supertokens_python/recipe/passwordless/__init__.py
+++ b/supertokens_python/recipe/passwordless/__init__.py
@@ -19,10 +19,8 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Union
 from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryConfig
 from supertokens_python.ingredients.smsdelivery.types import SMSDeliveryConfig
-from supertokens_python.recipe.passwordless.interfaces import \
-    PasswordlessLoginEmailTemplateVars
 from supertokens_python.recipe.passwordless.types import \
-    PasswordlessLoginSMSTemplateVars
+    EmailTemplateVars, SMSTemplateVars
 from typing_extensions import Literal
 
 from . import types, utils
@@ -54,8 +52,8 @@ def init(contact_config: ContactConfig,
          get_link_domain_and_path: Union[Callable[[
              PhoneOrEmailInput, Dict[str, Any]], Awaitable[str]], None] = None,
          get_custom_user_input_code: Union[Callable[[Dict[str, Any]], Awaitable[str]], None] = None,
-         email_delivery: Union[EmailDeliveryConfig[PasswordlessLoginEmailTemplateVars], None] = None,
-         sms_delivery: Union[SMSDeliveryConfig[PasswordlessLoginSMSTemplateVars], None] = None,
+         email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
+         sms_delivery: Union[SMSDeliveryConfig[SMSTemplateVars], None] = None,
          ) -> Callable[[AppInfo], RecipeModule]:
     return PasswordlessRecipe.init(contact_config,
                                    flow_type,

--- a/supertokens_python/recipe/passwordless/asyncio/__init__.py
+++ b/supertokens_python/recipe/passwordless/asyncio/__init__.py
@@ -25,8 +25,8 @@ from supertokens_python.recipe.passwordless.interfaces import (
     UpdateUserPhoneNumberAlreadyExistsError, UpdateUserUnknownUserIdError)
 from supertokens_python.recipe.passwordless.recipe import PasswordlessRecipe
 from supertokens_python.recipe.passwordless.types import (
-    DeviceType, PasswordlessLoginEmailTemplateVars,
-    PasswordlessLoginSMSTemplateVars, User)
+    DeviceType, EmailTemplateVars,
+    SMSTemplateVars, User)
 
 
 async def create_code(email: Union[None, str] = None,
@@ -145,13 +145,13 @@ async def signinup(email: Union[str, None], phone_number: Union[str, None], user
     return await PasswordlessRecipe.get_instance().signinup(email=email, phone_number=phone_number, user_context=user_context)
 
 
-async def send_email(input_: PasswordlessLoginEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await PasswordlessRecipe.get_instance().email_delivery.ingredient_interface_impl.send_email(input_, user_context)
 
 
-async def send_sms(input_: PasswordlessLoginSMSTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_sms(input_: SMSTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await PasswordlessRecipe.get_instance().sms_delivery.ingredient_interface_impl.send_sms(input_, user_context)

--- a/supertokens_python/recipe/passwordless/types.py
+++ b/supertokens_python/recipe/passwordless/types.py
@@ -86,15 +86,6 @@ class CreateAndSendCustomTextMessageParameters:
 PasswordlessLoginSMSTemplateVars = CreateAndSendCustomTextMessageParameters
 
 
-class PasswordlessIngredients:
-    def __init__(self,
-                 email_delivery: Union[EmailDeliveryIngredient[PasswordlessLoginEmailTemplateVars], None] = None,
-                 sms_delivery: Union[SMSDeliveryIngredient[PasswordlessLoginSMSTemplateVars], None] = None,
-                 ):
-        self.email_delivery = email_delivery
-        self.sms_delivery = sms_delivery
-
-
 # Export:
 EmailTemplateVars = PasswordlessLoginEmailTemplateVars
 SMSTemplateVars = PasswordlessLoginSMSTemplateVars
@@ -104,3 +95,12 @@ TwilioOverrideInput = TwilioServiceInterface[SMSTemplateVars]
 
 EmailDeliveryOverrideInput = EmailDeliveryInterface[EmailTemplateVars]
 SMSDeliveryOverrideInput = SMSDeliveryInterface[SMSTemplateVars]
+
+
+class PasswordlessIngredients:
+    def __init__(self,
+                 email_delivery: Union[EmailDeliveryIngredient[EmailTemplateVars], None] = None,
+                 sms_delivery: Union[SMSDeliveryIngredient[SMSTemplateVars], None] = None,
+                 ):
+        self.email_delivery = email_delivery
+        self.sms_delivery = sms_delivery

--- a/supertokens_python/recipe/thirdparty/__init__.py
+++ b/supertokens_python/recipe/thirdparty/__init__.py
@@ -23,7 +23,7 @@ from . import exceptions as ex
 from . import providers, utils
 from .emaildelivery import services as emaildelivery_services
 from .recipe import ThirdPartyRecipe
-from .types import ThirdPartyEmailTemplateVars
+from .types import EmailTemplateVars
 
 InputEmailVerificationConfig = utils.InputEmailVerificationConfig
 InputOverrideConfig = utils.InputOverrideConfig
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 def init(sign_in_and_up_feature: SignInAndUpFeature,
          email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
          override: Union[InputOverrideConfig, None] = None,
-         email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailTemplateVars], None] = None
+         email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
          ) -> Callable[[AppInfo], RecipeModule]:
     return ThirdPartyRecipe.init(
         sign_in_and_up_feature, email_verification_feature, override, email_delivery)

--- a/supertokens_python/recipe/thirdparty/asyncio/__init__.py
+++ b/supertokens_python/recipe/thirdparty/asyncio/__init__.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Union
 
 from supertokens_python.recipe.thirdparty.recipe import ThirdPartyRecipe
 
-from ..types import ThirdPartyEmailTemplateVars, User
+from ..types import EmailTemplateVars, User
 
 
 async def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -85,7 +85,7 @@ async def sign_in_up(third_party_id: str, third_party_user_id: str, email: str, 
                                                                                   email, email_verified, user_context)
 
 
-async def send_email(input_: ThirdPartyEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await ThirdPartyRecipe.get_instance().email_delivery.ingredient_interface_impl.send_email(input_, user_context)

--- a/supertokens_python/recipe/thirdparty/emaildelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/thirdparty/emaildelivery/services/backward_compatibility/__init__.py
@@ -22,7 +22,7 @@ from supertokens_python.recipe.emailverification.emaildelivery.services.backward
 from supertokens_python.recipe.emailverification.types import User
 from supertokens_python.recipe.thirdparty.interfaces import RecipeInterface
 from supertokens_python.recipe.thirdparty.types import \
-    ThirdPartyEmailTemplateVars
+    EmailTemplateVars
 from supertokens_python.supertokens import AppInfo
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
         InputEmailVerificationConfig
 
 
-class BackwardCompatibilityService(EmailDeliveryInterface[ThirdPartyEmailTemplateVars]):
+class BackwardCompatibilityService(EmailDeliveryInterface[EmailTemplateVars]):
     def __init__(self,
                  app_info: AppInfo,
                  recipe_interface_impl: RecipeInterface,
@@ -50,5 +50,5 @@ class BackwardCompatibilityService(EmailDeliveryInterface[ThirdPartyEmailTemplat
 
         self.ev_backward_compatibility_service = EVBackwardCompatibilityService(app_info, email_verification_feature_config)
 
-    async def send_email(self, template_vars: ThirdPartyEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         await self.ev_backward_compatibility_service.send_email(template_vars, user_context)

--- a/supertokens_python/recipe/thirdparty/emaildelivery/services/smtp/__init__.py
+++ b/supertokens_python/recipe/thirdparty/emaildelivery/services/smtp/__init__.py
@@ -19,15 +19,15 @@ from supertokens_python.ingredients.emaildelivery.types import \
 from supertokens_python.recipe.emailverification.emaildelivery.services.smtp import \
     SMTPService as EmailVerificationSMTPService
 from supertokens_python.recipe.thirdparty.types import \
-    ThirdPartyEmailTemplateVars, SMTPOverrideInput
+    EmailTemplateVars, SMTPOverrideInput
 
 
-class SMTPService(EmailDeliveryInterface[ThirdPartyEmailTemplateVars]):
+class SMTPService(EmailDeliveryInterface[EmailTemplateVars]):
     ev_smtp_service: EmailVerificationSMTPService
 
     def __init__(self, smtp_settings: SMTPSettings,
                  override: Union[Callable[[SMTPOverrideInput], SMTPOverrideInput], None] = None) -> None:
         self.ev_smtp_service = EmailVerificationSMTPService(smtp_settings, override)
 
-    async def send_email(self, template_vars: ThirdPartyEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         await self.ev_smtp_service.send_email(template_vars, user_context)

--- a/supertokens_python/recipe/thirdparty/recipe.py
+++ b/supertokens_python/recipe/thirdparty/recipe.py
@@ -45,7 +45,7 @@ from .api import (handle_apple_redirect_api, handle_authorisation_url_api,
                   handle_sign_in_up_api)
 from .constants import APPLE_REDIRECT_HANDLER, AUTHORISATIONURL, SIGNINUP
 from .exceptions import SuperTokensThirdPartyError
-from .types import ThirdPartyIngredients, ThirdPartyEmailTemplateVars
+from .types import ThirdPartyIngredients, EmailTemplateVars
 from .utils import (InputEmailVerificationConfig,
                     validate_and_normalise_user_input)
 
@@ -53,7 +53,7 @@ from .utils import (InputEmailVerificationConfig,
 class ThirdPartyRecipe(RecipeModule):
     recipe_id = 'thirdparty'
     __instance = None
-    email_delivery: EmailDeliveryIngredient[ThirdPartyEmailTemplateVars]
+    email_delivery: EmailDeliveryIngredient[EmailTemplateVars]
 
     def __init__(self, recipe_id: str, app_info: AppInfo,
                  sign_in_and_up_feature: SignInAndUpFeature,
@@ -61,7 +61,7 @@ class ThirdPartyRecipe(RecipeModule):
                  email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
                  override: Union[InputOverrideConfig, None] = None,
                  email_verification_recipe: Union[EmailVerificationRecipe, None] = None,
-                 email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailTemplateVars], None] = None,
+                 email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
                  ):
         super().__init__(recipe_id, app_info)
         self.config = validate_and_normalise_user_input(self, sign_in_and_up_feature,
@@ -131,7 +131,7 @@ class ThirdPartyRecipe(RecipeModule):
     def init(sign_in_and_up_feature: SignInAndUpFeature,
              email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
              override: Union[InputOverrideConfig, None] = None,
-             email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailTemplateVars], None] = None
+             email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
              ):
         def func(app_info: AppInfo):
             if ThirdPartyRecipe.__instance is None:

--- a/supertokens_python/recipe/thirdparty/syncio/__init__.py
+++ b/supertokens_python/recipe/thirdparty/syncio/__init__.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Union
 
 from supertokens_python.async_to_sync_wrapper import sync
 
-from ..types import ThirdPartyEmailTemplateVars, User
+from ..types import EmailTemplateVars, User
 
 
 def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -71,6 +71,6 @@ def sign_in_up(third_party_id: str, third_party_user_id: str,
                            third_party_user_id, email, email_verified, user_context))
 
 
-def send_email(input_: ThirdPartyEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     from supertokens_python.recipe.thirdparty.asyncio import send_email
     return sync(send_email(input_, user_context))

--- a/supertokens_python/recipe/thirdparty/types.py
+++ b/supertokens_python/recipe/thirdparty/types.py
@@ -74,20 +74,17 @@ class UsersResponse:
         self.next_pagination_token = next_pagination_token
 
 
-ThirdPartyEmailTemplateVars = ev_types.VerificationEmailTemplateVars
-
-
-class ThirdPartyIngredients:
-    def __init__(self,
-                 email_delivery: Union[EmailDeliveryIngredient[ThirdPartyEmailTemplateVars], None] = None
-                 ) -> None:
-        self.email_delivery = email_delivery
-
-
 # Export:
-EmailTemplateVars = ThirdPartyEmailTemplateVars
+EmailTemplateVars = ev_types.VerificationEmailTemplateVars
 VerificationEmailTemplateVars = ev_types.VerificationEmailTemplateVars
 
 SMTPOverrideInput = SMTPServiceInterface[EmailTemplateVars]
 
 EmailDeliveryOverrideInput = EmailDeliveryInterface[EmailTemplateVars]
+
+
+class ThirdPartyIngredients:
+    def __init__(self,
+                 email_delivery: Union[EmailDeliveryIngredient[EmailTemplateVars], None] = None
+                 ) -> None:
+        self.email_delivery = email_delivery

--- a/supertokens_python/recipe/thirdparty/utils.py
+++ b/supertokens_python/recipe/thirdparty/utils.py
@@ -36,7 +36,7 @@ from supertokens_python.recipe.emailverification.utils import \
     ParentRecipeEmailVerificationConfig
 
 from ..emailverification.types import User as EmailVerificationUser
-from .types import ThirdPartyEmailTemplateVars, User
+from .types import EmailTemplateVars, User
 
 
 class SignInAndUpFeature:
@@ -159,7 +159,7 @@ class ThirdPartyConfig:
                  sign_in_and_up_feature: SignInAndUpFeature,
                  email_verification_feature: ParentRecipeEmailVerificationConfig,
                  override: OverrideConfig,
-                 get_email_delivery_config: Callable[[RecipeInterface], EmailDeliveryConfigWithService[ThirdPartyEmailTemplateVars]],
+                 get_email_delivery_config: Callable[[RecipeInterface], EmailDeliveryConfigWithService[EmailTemplateVars]],
                  ):
         self.sign_in_and_up_feature = sign_in_and_up_feature
         self.email_verification_feature = email_verification_feature
@@ -172,7 +172,7 @@ def validate_and_normalise_user_input(
         sign_in_and_up_feature: SignInAndUpFeature,
         email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
         override: Union[InputOverrideConfig, None] = None,
-        email_delivery_config: Union[EmailDeliveryConfig[ThirdPartyEmailTemplateVars], None] = None
+        email_delivery_config: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
 ) -> ThirdPartyConfig:
     if not isinstance(sign_in_and_up_feature, SignInAndUpFeature):  # type: ignore
         raise ValueError('sign_in_and_up_feature must be an instance of SignInAndUpFeature')
@@ -184,7 +184,7 @@ def validate_and_normalise_user_input(
         override = InputOverrideConfig()
 
     def get_email_delivery_config(tp_recipe: RecipeInterface
-                                  ) -> EmailDeliveryConfigWithService[ThirdPartyEmailTemplateVars]:
+                                  ) -> EmailDeliveryConfigWithService[EmailTemplateVars]:
         if email_delivery_config and email_delivery_config.service:
             return EmailDeliveryConfigWithService(
                 email_delivery_config.service,

--- a/supertokens_python/recipe/thirdpartyemailpassword/__init__.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/__init__.py
@@ -19,7 +19,7 @@ from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryConfig
 from supertokens_python.recipe.thirdparty.provider import Provider
 from supertokens_python.recipe.thirdpartyemailpassword.types import \
-    ThirdPartyEmailPasswordEmailTemplateVars
+    EmailTemplateVars
 
 from .. import emailpassword, thirdparty
 from . import exceptions as ex
@@ -51,7 +51,7 @@ def init(sign_up_feature: Union[InputSignUpFeature, None] = None,
          email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
          override: Union[InputOverrideConfig, None] = None,
          providers: Union[List[Provider], None] = None,
-         email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailPasswordEmailTemplateVars], None] = None
+         email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
          ) -> Callable[[AppInfo], RecipeModule]:
     return ThirdPartyEmailPasswordRecipe.init(sign_up_feature, reset_password_using_token_feature,
                                               email_verification_feature,

--- a/supertokens_python/recipe/thirdpartyemailpassword/asyncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/asyncio/__init__.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Union
 from supertokens_python.recipe.thirdpartyemailpassword.recipe import \
     ThirdPartyEmailPasswordRecipe
 
-from ..types import ThirdPartyEmailPasswordEmailTemplateVars, User
+from ..types import EmailTemplateVars, User
 
 
 async def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -114,7 +114,7 @@ async def get_users_by_email(email: str, user_context: Union[None, Dict[str, Any
     return await ThirdPartyEmailPasswordRecipe.get_instance().recipe_implementation.get_users_by_email(email, user_context)
 
 
-async def send_email(input_: ThirdPartyEmailPasswordEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await ThirdPartyEmailPasswordRecipe.get_instance().email_delivery.ingredient_interface_impl.send_email(

--- a/supertokens_python/recipe/thirdpartyemailpassword/emaildelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/emaildelivery/services/backward_compatibility/__init__.py
@@ -27,11 +27,11 @@ from supertokens_python.recipe.emailpassword.utils import \
     InputResetPasswordUsingTokenFeature
 from supertokens_python.recipe.emailverification.emaildelivery.services.backward_compatibility import \
     BackwardCompatibilityService as EVBackwardCompatibilityService
-from supertokens_python.recipe.emailverification.types import User as EVUser, VerificationEmailTemplateVars
+from supertokens_python.recipe.emailverification.types import User as EVUser
 from supertokens_python.recipe.thirdpartyemailpassword.interfaces import \
     RecipeInterface
-from supertokens_python.recipe.thirdpartyemailpassword.types import \
-    ThirdPartyEmailPasswordEmailTemplateVars
+from supertokens_python.recipe.thirdpartyemailpassword.types import (
+    EmailTemplateVars, VerificationEmailTemplateVars)
 from supertokens_python.supertokens import AppInfo
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
         InputEmailVerificationConfig
 
 
-class BackwardCompatibilityService(EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]):
+class BackwardCompatibilityService(EmailDeliveryInterface[EmailTemplateVars]):
     ep_backward_compatiblity_service: EPBackwardCompatibilityService
     ev_backward_compatiblity_service: EVBackwardCompatibilityService
 
@@ -75,7 +75,7 @@ class BackwardCompatibilityService(EmailDeliveryInterface[ThirdPartyEmailPasswor
             ep_email_verification_feature,
         )
 
-    async def send_email(self, template_vars: ThirdPartyEmailPasswordEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             await self.ev_backward_compatiblity_service.send_email(template_vars, user_context)
 

--- a/supertokens_python/recipe/thirdpartyemailpassword/emaildelivery/services/smtp/__init__.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/emaildelivery/services/smtp/__init__.py
@@ -19,10 +19,10 @@ from supertokens_python.ingredients.emaildelivery.types import \
 from supertokens_python.recipe.emailpassword.emaildelivery.services.smtp import \
     SMTPService as EmailPasswordSMTPService
 from supertokens_python.recipe.thirdpartyemailpassword.types import \
-    ThirdPartyEmailPasswordEmailTemplateVars, SMTPOverrideInput
+    EmailTemplateVars, SMTPOverrideInput
 
 
-class SMTPService(EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]):
+class SMTPService(EmailDeliveryInterface[EmailTemplateVars]):
     ep_smtp_service: EmailPasswordSMTPService
 
     def __init__(self, smtp_settings: SMTPSettings,
@@ -30,7 +30,7 @@ class SMTPService(EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVar
         self.ep_smtp_service = EmailPasswordSMTPService(smtp_settings, override)
 
     async def send_email(self,
-                         template_vars: ThirdPartyEmailPasswordEmailTemplateVars,
+                         template_vars: EmailTemplateVars,
                          user_context: Dict[str, Any]
                          ) -> None:
         await self.ep_smtp_service.send_email(template_vars, user_context)

--- a/supertokens_python/recipe/thirdpartyemailpassword/recipe.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/recipe.py
@@ -23,14 +23,14 @@ from supertokens_python.normalised_url_path import NormalisedURLPath
 from supertokens_python.querier import Querier
 from supertokens_python.recipe.emailpassword.types import \
     EmailPasswordIngredients
-from supertokens_python.recipe.emailverification.types import \
-    EmailVerificationIngredients, VerificationEmailTemplateVars
+from supertokens_python.recipe.emailverification.types import (
+    EmailVerificationIngredients, VerificationEmailTemplateVars)
 from supertokens_python.recipe.thirdparty.provider import Provider
-from supertokens_python.recipe.thirdparty.types import (
-    ThirdPartyIngredients, ThirdPartyEmailTemplateVars)
+from supertokens_python.recipe.thirdparty.types import \
+    EmailTemplateVars as ThirdPartyEmailTemplateVars
+from supertokens_python.recipe.thirdparty.types import ThirdPartyIngredients
 from supertokens_python.recipe.thirdpartyemailpassword.types import (
-    ThirdPartyEmailPasswordIngredients,
-    ThirdPartyEmailPasswordEmailTemplateVars)
+    EmailTemplateVars, ThirdPartyEmailPasswordIngredients)
 from supertokens_python.recipe_module import APIHandled, RecipeModule
 
 from ..emailpassword.utils import (InputResetPasswordUsingTokenFeature,
@@ -78,7 +78,7 @@ from .utils import InputOverrideConfig, validate_and_normalise_user_input
 class ThirdPartyEmailPasswordRecipe(RecipeModule):
     recipe_id = 'thirdpartyemailpassword'
     __instance = None
-    email_delivery: EmailDeliveryIngredient[ThirdPartyEmailPasswordEmailTemplateVars]
+    email_delivery: EmailDeliveryIngredient[EmailTemplateVars]
 
     def __init__(self, recipe_id: str, app_info: AppInfo,
                  ingredients: ThirdPartyEmailPasswordIngredients,
@@ -90,7 +90,7 @@ class ThirdPartyEmailPasswordRecipe(RecipeModule):
                  email_verification_recipe: Union[EmailVerificationRecipe, None] = None,
                  email_password_recipe: Union[EmailPasswordRecipe, None] = None,
                  third_party_recipe: Union[ThirdPartyRecipe, None] = None,
-                 email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailPasswordEmailTemplateVars], None] = None,
+                 email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
                  ):
         super().__init__(recipe_id, app_info)
         self.config = validate_and_normalise_user_input(self,
@@ -240,7 +240,7 @@ class ThirdPartyEmailPasswordRecipe(RecipeModule):
              email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
              override: Union[InputOverrideConfig, None] = None,
              providers: Union[List[Provider], None] = None,
-             email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailPasswordEmailTemplateVars], None] = None
+             email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None
              ):
         def func(app_info: AppInfo):
             if ThirdPartyEmailPasswordRecipe.__instance is None:

--- a/supertokens_python/recipe/thirdpartyemailpassword/syncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/syncio/__init__.py
@@ -18,7 +18,7 @@ from supertokens_python.async_to_sync_wrapper import sync
 
 from ..interfaces import (EmailPasswordSignInOkResult,
                           EmailPasswordSignInWrongCredentialsError)
-from ..types import ThirdPartyEmailPasswordEmailTemplateVars, User
+from ..types import EmailTemplateVars, User
 
 
 def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -112,7 +112,7 @@ def revoke_email_verification_tokens(user_id: str, user_context: Union[None, Dic
 
 
 def send_email(
-    input_: ThirdPartyEmailPasswordEmailTemplateVars,
+    input_: EmailTemplateVars,
     user_context: Union[None, Dict[str, Any]] = None
 ):
     from supertokens_python.recipe.thirdpartyemailpassword.asyncio import \

--- a/supertokens_python/recipe/thirdpartyemailpassword/types.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/types.py
@@ -32,21 +32,18 @@ class User:
         self.third_party_info = third_party_info
 
 
-ThirdPartyEmailPasswordEmailTemplateVars = ep_types.EmailPasswordEmailTemplateVars
-
-
-class ThirdPartyEmailPasswordIngredients:
-    def __init__(self,
-                 email_delivery: Union[EmailDeliveryIngredient[ThirdPartyEmailPasswordEmailTemplateVars], None] = None
-                 ) -> None:
-        self.email_delivery = email_delivery
-
-
 # Export:
-EmailTemplateVars = ThirdPartyEmailPasswordEmailTemplateVars
+EmailTemplateVars = ep_types.EmailTemplateVars
 VerificationEmailTemplateVars = ep_types.VerificationEmailTemplateVars
 PasswordResetEmailTemplateVars = ep_types.PasswordResetEmailTemplateVars
 
 SMTPOverrideInput = SMTPServiceInterface[EmailTemplateVars]
 
 EmailDeliveryOverrideInput = EmailDeliveryInterface[EmailTemplateVars]
+
+
+class ThirdPartyEmailPasswordIngredients:
+    def __init__(self,
+                 email_delivery: Union[EmailDeliveryIngredient[EmailTemplateVars], None] = None
+                 ) -> None:
+        self.email_delivery = email_delivery

--- a/supertokens_python/recipe/thirdpartyemailpassword/utils.py
+++ b/supertokens_python/recipe/thirdpartyemailpassword/utils.py
@@ -28,7 +28,7 @@ from ..emailverification.types import User as EmailVerificationUser
 from .emaildelivery.services.backward_compatibility import \
     BackwardCompatibilityService
 from .interfaces import APIInterface, RecipeInterface
-from .types import ThirdPartyEmailPasswordEmailTemplateVars, User
+from .types import EmailTemplateVars, User
 
 if TYPE_CHECKING:
     from .recipe import ThirdPartyEmailPasswordRecipe
@@ -121,7 +121,7 @@ class ThirdPartyEmailPasswordConfig:
                  email_verification_feature: ParentRecipeEmailVerificationConfig,
                  sign_up_feature: Union[InputSignUpFeature, None],
                  reset_password_using_token_feature: Union[InputResetPasswordUsingTokenFeature, None],
-                 get_email_delivery_config: Callable[[RecipeInterface, EPRecipeInterface], EmailDeliveryConfigWithService[ThirdPartyEmailPasswordEmailTemplateVars]],
+                 get_email_delivery_config: Callable[[RecipeInterface, EPRecipeInterface], EmailDeliveryConfigWithService[EmailTemplateVars]],
                  override: OverrideConfig
                  ):
         self.sign_up_feature = sign_up_feature
@@ -139,7 +139,7 @@ def validate_and_normalise_user_input(
         email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
         override: Union[InputOverrideConfig, None] = None,
         providers: Union[List[Provider], None] = None,
-        email_delivery: Union[EmailDeliveryConfig[ThirdPartyEmailPasswordEmailTemplateVars], None] = None,
+        email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
 ) -> ThirdPartyEmailPasswordConfig:
     if sign_up_feature is not None and not isinstance(sign_up_feature, InputSignUpFeature):  # type: ignore
         raise ValueError('sign_up_feature must be of type InputSignUpFeature or None')

--- a/supertokens_python/recipe/thirdpartypasswordless/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/__init__.py
@@ -27,8 +27,8 @@ from . import utils
 from .emaildelivery import services as emaildelivery_services
 from .recipe import ThirdPartyPasswordlessRecipe
 from .smsdelivery import services as smsdelivery_services
-from .types import (ThirdPartyPasswordlessEmailTemplateVars,
-                    ThirdPartyPasswordlessSMSTemplateVars)
+from .types import (EmailTemplateVars,
+                    SMSTemplateVars)
 
 InputEmailVerificationConfig = utils.InputEmailVerificationConfig
 InputOverrideConfig = utils.InputOverrideConfig
@@ -60,8 +60,10 @@ def init(contact_config: ContactConfig,
              PhoneOrEmailInput, Dict[str, Any]], Awaitable[str]], None] = None,
          get_custom_user_input_code: Union[Callable[[Dict[str, Any]], Awaitable[str]], None] = None,
          email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
-         email_delivery: Union[EmailDeliveryConfig[ThirdPartyPasswordlessEmailTemplateVars], None] = None,
-         sms_delivery: Union[SMSDeliveryConfig[ThirdPartyPasswordlessSMSTemplateVars], None] = None,
+         email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
+         sms_delivery: Union[SMSDeliveryConfig[SMSTemplateVars], None] = None,
          override: Union[InputOverrideConfig, None] = None,
          providers: Union[List[Provider], None] = None) -> Callable[[AppInfo], RecipeModule]:
-    return ThirdPartyPasswordlessRecipe.init(contact_config, flow_type, get_link_domain_and_path, get_custom_user_input_code, email_verification_feature, email_delivery, sms_delivery, override, providers)
+    return ThirdPartyPasswordlessRecipe.init(contact_config, flow_type, get_link_domain_and_path,
+                                             get_custom_user_input_code, email_verification_feature,
+                                             email_delivery, sms_delivery, override, providers)

--- a/supertokens_python/recipe/thirdpartypasswordless/asyncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/asyncio/__init__.py
@@ -19,8 +19,8 @@ from supertokens_python.recipe.passwordless.interfaces import (
 
 from .. import interfaces
 from ..recipe import ThirdPartyPasswordlessRecipe
-from ..types import (ThirdPartyPasswordlessEmailTemplateVars,
-                     ThirdPartyPasswordlessSMSTemplateVars, User)
+from ..types import (EmailTemplateVars,
+                     SMSTemplateVars, User)
 
 
 async def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -194,13 +194,13 @@ async def passwordlessSigninup(email: Union[str, None], phone_number: Union[str,
     )
 
 
-async def send_email(input_: ThirdPartyPasswordlessEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await ThirdPartyPasswordlessRecipe.get_instance().email_delivery.ingredient_interface_impl.send_email(input_, user_context)
 
 
-async def send_sms(input_: ThirdPartyPasswordlessSMSTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+async def send_sms(input_: SMSTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     if user_context is None:
         user_context = {}
     return await ThirdPartyPasswordlessRecipe.get_instance().sms_delivery.ingredient_interface_impl.send_sms(input_, user_context)

--- a/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/backward_compatibility/__init__.py
@@ -29,7 +29,7 @@ from supertokens_python.recipe.passwordless.types import \
 from supertokens_python.recipe.thirdpartypasswordless.interfaces import \
     RecipeInterface
 from supertokens_python.recipe.thirdpartypasswordless.types import \
-    ThirdPartyPasswordlessEmailTemplateVars
+    EmailTemplateVars
 from supertokens_python.supertokens import AppInfo
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         InputEmailVerificationConfig
 
 
-class BackwardCompatibilityService(EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+class BackwardCompatibilityService(EmailDeliveryInterface[EmailTemplateVars]):
     pless_backward_compatiblity_service: PlessBackwardCompatibilityService
     ev_backward_compatiblity_service: EVBackwardCompatibilityService
 
@@ -74,7 +74,7 @@ class BackwardCompatibilityService(EmailDeliveryInterface[ThirdPartyPasswordless
             create_and_send_custom_email
         )
 
-    async def send_email(self, template_vars: ThirdPartyPasswordlessEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             await self.ev_backward_compatiblity_service.send_email(template_vars, user_context)
         else:

--- a/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/__init__.py
@@ -24,7 +24,7 @@ from supertokens_python.recipe.emailverification.types import VerificationEmailT
 from supertokens_python.recipe.passwordless.emaildelivery.services.smtp import \
     SMTPService as PlessSMTPService
 from supertokens_python.recipe.thirdpartypasswordless.types import \
-    ThirdPartyPasswordlessEmailTemplateVars, SMTPOverrideInput
+    EmailTemplateVars, SMTPOverrideInput
 
 from .service_implementation import ServiceImplementation
 from .service_implementation.email_verification_implementation import \
@@ -33,7 +33,7 @@ from .service_implementation.passwordless_implementation import \
     ServiceImplementation as PlessServiceImpl
 
 
-class SMTPService(EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+class SMTPService(EmailDeliveryInterface[EmailTemplateVars]):
 
     def __init__(self, smtp_settings: SMTPSettings,
                  override: Union[Callable[[SMTPOverrideInput], SMTPOverrideInput], None] = None) -> None:
@@ -52,7 +52,7 @@ class SMTPService(EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars
             override=lambda _: PlessServiceImpl(service_implementation)
         )
 
-    async def send_email(self, template_vars: ThirdPartyPasswordlessEmailTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_email(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> None:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             return await self.ev_smtp_service.send_email(template_vars, user_context)
 

--- a/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/service_implementation/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/service_implementation/__init__.py
@@ -23,7 +23,7 @@ from supertokens_python.recipe.emailverification.types import VerificationEmailT
 from supertokens_python.recipe.passwordless.emaildelivery.services.smtp.service_implementation import \
     ServiceImplementation as PlessServiceImplementation
 from supertokens_python.recipe.thirdpartypasswordless.types import \
-    ThirdPartyPasswordlessEmailTemplateVars
+    EmailTemplateVars
 
 from .email_verification_implementation import \
     ServiceImplementation as DerivedEVServiceImplementation
@@ -31,7 +31,7 @@ from .passwordless_implementation import \
     ServiceImplementation as DerivedPlessServiceImplementation
 
 
-class ServiceImplementation(SMTPServiceInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+class ServiceImplementation(SMTPServiceInterface[EmailTemplateVars]):
     def __init__(self, transporter: Transporter) -> None:
         super().__init__(transporter)
 
@@ -56,7 +56,7 @@ class ServiceImplementation(SMTPServiceInterface[ThirdPartyPasswordlessEmailTemp
     async def send_raw_email(self, content: EmailContent, user_context: Dict[str, Any]) -> None:
         await self.transporter.send_email(content, user_context)
 
-    async def get_content(self, template_vars: ThirdPartyPasswordlessEmailTemplateVars, user_context: Dict[str, Any]) -> EmailContent:
+    async def get_content(self, template_vars: EmailTemplateVars, user_context: Dict[str, Any]) -> EmailContent:
         if isinstance(template_vars, VerificationEmailTemplateVars):
             return await self.ev_get_content(template_vars, user_context)
 

--- a/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/service_implementation/email_verification_implementation.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/service_implementation/email_verification_implementation.py
@@ -18,11 +18,11 @@ from supertokens_python.ingredients.emaildelivery.types import EmailContent, SMT
 from supertokens_python.recipe.emailverification.types import \
     VerificationEmailTemplateVars
 from supertokens_python.recipe.thirdpartypasswordless.types import \
-    ThirdPartyPasswordlessEmailTemplateVars
+    EmailTemplateVars
 
 
 class ServiceImplementation(SMTPServiceInterface[VerificationEmailTemplateVars]):
-    def __init__(self, tppless_service_implementation: SMTPServiceInterface[ThirdPartyPasswordlessEmailTemplateVars]) -> None:
+    def __init__(self, tppless_service_implementation: SMTPServiceInterface[EmailTemplateVars]) -> None:
         super().__init__(tppless_service_implementation.transporter)
         self.tppless_service_implementation = tppless_service_implementation
 

--- a/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/service_implementation/passwordless_implementation.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/emaildelivery/services/smtp/service_implementation/passwordless_implementation.py
@@ -15,14 +15,12 @@
 from typing import Any, Dict
 
 from supertokens_python.ingredients.emaildelivery.types import EmailContent, SMTPServiceInterface
-from supertokens_python.recipe.passwordless.types import \
-    PasswordlessLoginEmailTemplateVars
 from supertokens_python.recipe.thirdpartypasswordless.types import \
-    ThirdPartyPasswordlessEmailTemplateVars
+    EmailTemplateVars, PasswordlessLoginEmailTemplateVars
 
 
 class ServiceImplementation(SMTPServiceInterface[PasswordlessLoginEmailTemplateVars]):
-    def __init__(self, tppless_service_implementation: SMTPServiceInterface[ThirdPartyPasswordlessEmailTemplateVars]) -> None:
+    def __init__(self, tppless_service_implementation: SMTPServiceInterface[EmailTemplateVars]) -> None:
         super().__init__(tppless_service_implementation.transporter)
         self.tppless_service_implementation = tppless_service_implementation
 

--- a/supertokens_python/recipe/thirdpartypasswordless/recipe.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/recipe.py
@@ -22,15 +22,17 @@ from supertokens_python.ingredients.emaildelivery.types import \
 from supertokens_python.normalised_url_path import NormalisedURLPath
 from supertokens_python.querier import Querier
 from supertokens_python.recipe.emailverification.types import \
-    EmailVerificationIngredients, VerificationEmailTemplateVars
+    EmailTemplateVars as EmailVerificationEmailTemplateVars
+from supertokens_python.recipe.emailverification.types import \
+    EmailVerificationIngredients
 from supertokens_python.recipe.passwordless.types import \
     PasswordlessIngredients
 from supertokens_python.recipe.thirdparty.provider import Provider
-from supertokens_python.recipe.thirdparty.types import (
-    ThirdPartyIngredients, ThirdPartyEmailTemplateVars)
+from supertokens_python.recipe.thirdparty.types import \
+    EmailTemplateVars as ThirdPartyEmailTemplateVars
+from supertokens_python.recipe.thirdparty.types import ThirdPartyIngredients
 from supertokens_python.recipe.thirdpartypasswordless.types import (
-    ThirdPartyPasswordlessIngredients,
-    ThirdPartyPasswordlessEmailTemplateVars)
+    EmailTemplateVars, ThirdPartyPasswordlessIngredients)
 from supertokens_python.recipe_module import APIHandled, RecipeModule
 
 from ..passwordless.utils import ContactConfig, PhoneOrEmailInput
@@ -71,25 +73,24 @@ from ..emailverification.interfaces import RecipeInterface as EVRecipeInterface
 from ..emailverification.utils import OverrideConfig as EVOverrideConfig
 from ..passwordless import PasswordlessRecipe
 from ..passwordless.interfaces import APIInterface as PasswordlessAPIInterface
+from ..passwordless.interfaces import PasswordlessLoginEmailTemplateVars
 from ..passwordless.interfaces import \
     RecipeInterface as PasswordlessRecipeInterface
-from ..passwordless.interfaces import PasswordlessLoginEmailTemplateVars
 from ..passwordless.utils import OverrideConfig as PlessOverrideConfig
 from ..thirdparty.interfaces import APIInterface as ThirdPartyAPIInterface
 from ..thirdparty.interfaces import \
     RecipeInterface as ThirdPartyRecipeInterface
 from .exceptions import SupertokensThirdPartyPasswordlessError
 from .interfaces import APIInterface, RecipeInterface
-from .types import (ThirdPartyPasswordlessEmailTemplateVars,
-                    ThirdPartyPasswordlessSMSTemplateVars)
+from .types import EmailTemplateVars, SMSTemplateVars
 from .utils import InputOverrideConfig, validate_and_normalise_user_input
 
 
 class ThirdPartyPasswordlessRecipe(RecipeModule):
     recipe_id = 'thirdpartypasswordless'
     __instance = None
-    email_delivery: EmailDeliveryIngredient[ThirdPartyPasswordlessEmailTemplateVars]
-    sms_delivery: SMSDeliveryIngredient[ThirdPartyPasswordlessSMSTemplateVars]
+    email_delivery: EmailDeliveryIngredient[EmailTemplateVars]
+    sms_delivery: SMSDeliveryIngredient[SMSTemplateVars]
 
     def __init__(self, recipe_id: str, app_info: AppInfo,
                  contact_config: ContactConfig,
@@ -103,8 +104,8 @@ class ThirdPartyPasswordlessRecipe(RecipeModule):
                  email_verification_recipe: Union[EmailVerificationRecipe, None] = None,
                  third_party_recipe: Union[ThirdPartyRecipe, None] = None,
                  passwordless_recipe: Union[PasswordlessRecipe, None] = None,
-                 email_delivery: Union[EmailDeliveryConfig[ThirdPartyPasswordlessEmailTemplateVars], None] = None,
-                 sms_delivery: Union[SMSDeliveryConfig[ThirdPartyPasswordlessSMSTemplateVars], None] = None,
+                 email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
+                 sms_delivery: Union[SMSDeliveryConfig[SMSTemplateVars], None] = None,
                  ):
         super().__init__(recipe_id, app_info)
         self.config = validate_and_normalise_user_input(self,
@@ -177,7 +178,7 @@ class ThirdPartyPasswordlessRecipe(RecipeModule):
             else:
                 self.config.email_verification_feature.override.functions = email_verification_override
 
-            ev_email_delivery = cast(EmailDeliveryIngredient[VerificationEmailTemplateVars], self.email_delivery)
+            ev_email_delivery = cast(EmailDeliveryIngredient[EmailVerificationEmailTemplateVars], self.email_delivery)
             ev_ingredients = EmailVerificationIngredients(ev_email_delivery)
             self.email_verification_recipe = EmailVerificationRecipe(recipe_id, app_info,
                                                                      self.config.email_verification_feature, ev_ingredients)
@@ -297,8 +298,8 @@ class ThirdPartyPasswordlessRecipe(RecipeModule):
                  PhoneOrEmailInput, Dict[str, Any]], Awaitable[str]], None] = None,
              get_custom_user_input_code: Union[Callable[[Dict[str, Any]], Awaitable[str]], None] = None,
              email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
-             email_delivery: Union[EmailDeliveryConfig[ThirdPartyPasswordlessEmailTemplateVars], None] = None,
-             sms_delivery: Union[SMSDeliveryConfig[ThirdPartyPasswordlessSMSTemplateVars], None] = None,
+             email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
+             sms_delivery: Union[SMSDeliveryConfig[SMSTemplateVars], None] = None,
              override: Union[InputOverrideConfig, None] = None,
              providers: Union[List[Provider], None] = None):
         def func(app_info: AppInfo):

--- a/supertokens_python/recipe/thirdpartypasswordless/smsdelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/smsdelivery/services/backward_compatibility/__init__.py
@@ -22,10 +22,10 @@ from supertokens_python.recipe.passwordless.types import \
     PasswordlessLoginSMSTemplateVars
 from supertokens_python.supertokens import AppInfo
 
-from ....types import ThirdPartyPasswordlessSMSTemplateVars
+from ....types import SMSTemplateVars
 
 
-class BackwardCompatibilityService(SMSDeliveryInterface[ThirdPartyPasswordlessSMSTemplateVars]):
+class BackwardCompatibilityService(SMSDeliveryInterface[SMSTemplateVars]):
     pless_backward_compatibility_service: PlessBackwardCompatibilityService
 
     def __init__(self, app_info: AppInfo,
@@ -35,5 +35,5 @@ class BackwardCompatibilityService(SMSDeliveryInterface[ThirdPartyPasswordlessSM
             app_info, pless_create_and_send_custom_text_message
         )
 
-    async def send_sms(self, template_vars: ThirdPartyPasswordlessSMSTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_sms(self, template_vars: SMSTemplateVars, user_context: Dict[str, Any]) -> None:
         await self.pless_backward_compatibility_service.send_sms(template_vars, user_context)

--- a/supertokens_python/recipe/thirdpartypasswordless/smsdelivery/services/supertokens/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/smsdelivery/services/supertokens/__init__.py
@@ -20,14 +20,14 @@ from supertokens_python.ingredients.smsdelivery.types import \
 from supertokens_python.recipe.passwordless.smsdelivery.services.supertokens import \
     SuperTokensSMSService as PlessSuperTokensService
 
-from ....types import ThirdPartyPasswordlessSMSTemplateVars
+from ....types import SMSTemplateVars
 
 
-class SuperTokensSMSService(SMSDeliveryInterface[ThirdPartyPasswordlessSMSTemplateVars]):
+class SuperTokensSMSService(SMSDeliveryInterface[SMSTemplateVars]):
     pless_supertokens_service: PlessSuperTokensService
 
     def __init__(self, api_key: str) -> None:
         self.pless_supertokens_service = PlessSuperTokensService(api_key)
 
-    async def send_sms(self, template_vars: ThirdPartyPasswordlessSMSTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_sms(self, template_vars: SMSTemplateVars, user_context: Dict[str, Any]) -> None:
         await self.pless_supertokens_service.send_sms(template_vars, user_context)

--- a/supertokens_python/recipe/thirdpartypasswordless/smsdelivery/services/twilio/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/smsdelivery/services/twilio/__init__.py
@@ -21,15 +21,15 @@ from supertokens_python.ingredients.smsdelivery.types import \
 from supertokens_python.recipe.passwordless.smsdelivery.services.twilio import \
     TwilioService as PlessTwilioService
 
-from ....types import ThirdPartyPasswordlessSMSTemplateVars
+from ....types import SMSTemplateVars
 
 
-class TwilioService(SMSDeliveryInterface[ThirdPartyPasswordlessSMSTemplateVars]):
+class TwilioService(SMSDeliveryInterface[SMSTemplateVars]):
     pless_twilio_service: PlessTwilioService
 
     def __init__(self, twilio_settings: TwilioSettings,
-                 override: Union[Callable[[TwilioServiceInterface[ThirdPartyPasswordlessSMSTemplateVars]], TwilioServiceInterface[ThirdPartyPasswordlessSMSTemplateVars]], None] = None) -> None:
+                 override: Union[Callable[[TwilioServiceInterface[SMSTemplateVars]], TwilioServiceInterface[SMSTemplateVars]], None] = None) -> None:
         self.pless_twilio_service = PlessTwilioService(twilio_settings, override)
 
-    async def send_sms(self, template_vars: ThirdPartyPasswordlessSMSTemplateVars, user_context: Dict[str, Any]) -> None:
+    async def send_sms(self, template_vars: SMSTemplateVars, user_context: Dict[str, Any]) -> None:
         await self.pless_twilio_service.send_sms(template_vars, user_context)

--- a/supertokens_python/recipe/thirdpartypasswordless/syncio/__init__.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/syncio/__init__.py
@@ -19,8 +19,8 @@ from supertokens_python.recipe.passwordless.interfaces import (
     DeleteUserInfoOkResult, DeleteUserInfoUnknownUserIdError)
 
 from .. import asyncio, interfaces
-from ..types import (ThirdPartyPasswordlessEmailTemplateVars,
-                     ThirdPartyPasswordlessSMSTemplateVars, User)
+from ..types import (EmailTemplateVars,
+                     SMSTemplateVars, User)
 
 
 def create_email_verification_token(user_id: str, user_context: Union[None, Dict[str, Any]] = None):
@@ -164,9 +164,9 @@ def passwordlessSigninup(email: Union[str, None], phone_number: Union[str,
         email=email, phone_number=phone_number, user_context=user_context))
 
 
-def send_email(input_: ThirdPartyPasswordlessEmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+def send_email(input_: EmailTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     return sync(asyncio.send_email(input_, user_context))
 
 
-def send_sms(input_: ThirdPartyPasswordlessSMSTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
+def send_sms(input_: SMSTemplateVars, user_context: Union[None, Dict[str, Any]] = None):
     return sync(asyncio.send_sms(input_, user_context))

--- a/supertokens_python/recipe/thirdpartypasswordless/types.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/types.py
@@ -38,27 +38,9 @@ class User:
 
 _T = TypeVar('_T')
 
-
-ThirdPartyPasswordlessEmailTemplateVars = Union[
-    tp_types.ThirdPartyEmailTemplateVars, pless_types.PasswordlessLoginEmailTemplateVars
-]
-
-
-ThirdPartyPasswordlessSMSTemplateVars = pless_types.PasswordlessLoginSMSTemplateVars
-
-
-class ThirdPartyPasswordlessIngredients:
-    def __init__(self,
-                 email_delivery: Union[EmailDeliveryIngredient[ThirdPartyPasswordlessEmailTemplateVars], None] = None,
-                 sms_delivery: Union[SMSDeliveryIngredient[ThirdPartyPasswordlessSMSTemplateVars], None] = None,
-                 ) -> None:
-        self.email_delivery = email_delivery
-        self.sms_delivery = sms_delivery
-
-
 # Export:
-EmailTemplateVars = ThirdPartyPasswordlessEmailTemplateVars
-SMSTemplateVars = ThirdPartyPasswordlessSMSTemplateVars
+EmailTemplateVars = Union[tp_types.EmailTemplateVars, pless_types.EmailTemplateVars]
+SMSTemplateVars = pless_types.SMSTemplateVars
 VerificationEmailTemplateVars = tp_types.VerificationEmailTemplateVars
 PasswordlessLoginEmailTemplateVars = pless_types.PasswordlessLoginEmailTemplateVars
 PasswordlessLoginSMSTemplateVars = pless_types.PasswordlessLoginSMSTemplateVars
@@ -68,3 +50,12 @@ TwilioOverrideInput = TwilioServiceInterface[SMSTemplateVars]
 
 EmailDeliveryOverrideInput = EmailDeliveryInterface[EmailTemplateVars]
 SMSDeliveryOverrideInput = SMSDeliveryInterface[SMSTemplateVars]
+
+
+class ThirdPartyPasswordlessIngredients:
+    def __init__(self,
+                 email_delivery: Union[EmailDeliveryIngredient[EmailTemplateVars], None] = None,
+                 sms_delivery: Union[SMSDeliveryIngredient[SMSTemplateVars], None] = None,
+                 ) -> None:
+        self.email_delivery = email_delivery
+        self.sms_delivery = sms_delivery

--- a/supertokens_python/recipe/thirdpartypasswordless/utils.py
+++ b/supertokens_python/recipe/thirdpartypasswordless/utils.py
@@ -27,7 +27,7 @@ from supertokens_python.recipe.thirdparty.provider import Provider
 from supertokens_python.recipe.thirdpartypasswordless.emaildelivery.services.backward_compatibility import \
     BackwardCompatibilityService
 from supertokens_python.recipe.thirdpartypasswordless.types import \
-    ThirdPartyPasswordlessSMSTemplateVars
+    SMSTemplateVars
 from supertokens_python.utils import deprecated_warn
 from typing_extensions import Literal
 
@@ -39,7 +39,7 @@ from ..passwordless.utils import (ContactConfig, ContactEmailOnlyConfig,
 if TYPE_CHECKING:
     from .recipe import ThirdPartyPasswordlessRecipe
     from .interfaces import APIInterface, RecipeInterface
-    from .types import ThirdPartyPasswordlessEmailTemplateVars, User
+    from .types import EmailTemplateVars, User
 
 from supertokens_python.recipe.emailverification.utils import \
     OverrideConfig as EmailVerificationOverrideConfig
@@ -137,10 +137,10 @@ class ThirdPartyPasswordlessConfig:
                  flow_type: Literal['USER_INPUT_CODE', 'MAGIC_LINK', 'USER_INPUT_CODE_AND_MAGIC_LINK'],
                  get_link_domain_and_path: Callable[[PhoneOrEmailInput, Dict[str, Any]], Awaitable[str]],
                  get_email_delivery_config: Callable[
-                     [RecipeInterface], EmailDeliveryConfigWithService[ThirdPartyPasswordlessEmailTemplateVars]
+                     [RecipeInterface], EmailDeliveryConfigWithService[EmailTemplateVars]
                  ],
                  get_sms_delivery_config: Callable[
-                     [], SMSDeliveryConfigWithService[ThirdPartyPasswordlessSMSTemplateVars]
+                     [], SMSDeliveryConfigWithService[SMSTemplateVars]
                  ],
                  get_custom_user_input_code: Union[Callable[[Dict[str, Any]], Awaitable[str]], None] = None
                  ):
@@ -165,8 +165,8 @@ def validate_and_normalise_user_input(
         email_verification_feature: Union[InputEmailVerificationConfig, None] = None,
         override: Union[InputOverrideConfig, None] = None,
         providers: Union[List[Provider], None] = None,
-        email_delivery: Union[EmailDeliveryConfig[ThirdPartyPasswordlessEmailTemplateVars], None] = None,
-        sms_delivery: Union[SMSDeliveryConfig[ThirdPartyPasswordlessSMSTemplateVars], None] = None,
+        email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
+        sms_delivery: Union[SMSDeliveryConfig[SMSTemplateVars], None] = None,
 ) -> ThirdPartyPasswordlessConfig:
     if not isinstance(contact_config, ContactConfig):  # type: ignore
         raise ValueError('contact_config must be an instance of ContactConfig')
@@ -197,7 +197,7 @@ def validate_and_normalise_user_input(
 
     def get_email_delivery_config(
         tppless_recipe: RecipeInterface,
-    ) -> EmailDeliveryConfigWithService[ThirdPartyPasswordlessEmailTemplateVars]:
+    ) -> EmailDeliveryConfigWithService[EmailTemplateVars]:
         email_service = email_delivery.service if email_delivery is not None else None
         if isinstance(contact_config, (ContactEmailOnlyConfig, ContactEmailOrPhoneConfig)):
             create_and_send_custom_email = contact_config.create_and_send_custom_email
@@ -215,7 +215,7 @@ def validate_and_normalise_user_input(
 
         return EmailDeliveryConfigWithService(email_service, override=override)
 
-    def get_sms_delivery_config() -> SMSDeliveryConfigWithService[ThirdPartyPasswordlessSMSTemplateVars]:
+    def get_sms_delivery_config() -> SMSDeliveryConfigWithService[SMSTemplateVars]:
         if sms_delivery and sms_delivery.service:
             return SMSDeliveryConfigWithService(
                 service=sms_delivery.service,

--- a/tests/emailpassword/test_emaildelivery.py
+++ b/tests/emailpassword/test_emaildelivery.py
@@ -33,7 +33,7 @@ from supertokens_python.recipe.emailpassword import (
 from supertokens_python.recipe.emailpassword.emaildelivery.services import \
     SMTPService
 from supertokens_python.recipe.emailpassword.types import (
-    EmailPasswordEmailTemplateVars, PasswordResetEmailTemplateVars)
+    EmailTemplateVars, PasswordResetEmailTemplateVars)
 from supertokens_python.recipe.emailpassword.types import User as EPUser
 from supertokens_python.recipe.emailverification.types import \
     VerificationEmailTemplateVars
@@ -204,10 +204,10 @@ async def test_reset_password_custom_override(driver_config_client: TestClient):
     password_reset_url = ""
     app_name = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[EmailPasswordEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, password_reset_url
             email = template_vars.user.email
             assert isinstance(template_vars, PasswordResetEmailTemplateVars)
@@ -263,7 +263,7 @@ async def test_reset_password_smtp_service(driver_config_client: TestClient):
     password_reset_url = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[EmailPasswordEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email
             send_raw_email_called = True
@@ -274,7 +274,7 @@ async def test_reset_password_smtp_service(driver_config_client: TestClient):
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: EmailPasswordEmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
+        async def get_content_override(template_vars: EmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, password_reset_url
             get_content_called = True
 
@@ -304,10 +304,10 @@ async def test_reset_password_smtp_service(driver_config_client: TestClient):
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[EmailPasswordEmailTemplateVars]) -> EmailDeliveryInterface[EmailPasswordEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email_override(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_email(template_vars, user_context)
@@ -350,7 +350,7 @@ async def test_reset_password_for_non_existent_user(driver_config_client: TestCl
     password_reset_url = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[EmailPasswordEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email
             send_raw_email_called = True
@@ -361,7 +361,7 @@ async def test_reset_password_for_non_existent_user(driver_config_client: TestCl
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: EmailPasswordEmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
+        async def get_content_override(template_vars: EmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, password_reset_url
             get_content_called = True
 
@@ -391,10 +391,10 @@ async def test_reset_password_for_non_existent_user(driver_config_client: TestCl
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[EmailPasswordEmailTemplateVars]) -> EmailDeliveryInterface[EmailPasswordEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email_override(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_email(template_vars, user_context)
@@ -609,10 +609,10 @@ async def test_email_verification_custom_override(driver_config_client: TestClie
     email = ""
     email_verify_url = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[EmailPasswordEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, email_verify_url
             email = template_vars.user.email
             assert isinstance(template_vars, VerificationEmailTemplateVars)
@@ -684,7 +684,7 @@ async def test_email_verification_smtp_service(driver_config_client: TestClient)
     email_verify_url = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[EmailPasswordEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email
             send_raw_email_called = True
@@ -695,7 +695,7 @@ async def test_email_verification_smtp_service(driver_config_client: TestClient)
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: EmailPasswordEmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
+        async def get_content_override(template_vars: EmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, email_verify_url
             get_content_called = True
 
@@ -725,10 +725,10 @@ async def test_email_verification_smtp_service(driver_config_client: TestClient)
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[EmailPasswordEmailTemplateVars]) -> EmailDeliveryInterface[EmailPasswordEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: EmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email_override(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_email(template_vars, user_context)

--- a/tests/passwordless/test_emaildelivery.py
+++ b/tests/passwordless/test_emaildelivery.py
@@ -31,7 +31,7 @@ from supertokens_python.recipe import passwordless, session
 from supertokens_python.recipe.passwordless.emaildelivery.services.smtp import \
     SMTPService
 from supertokens_python.recipe.passwordless.types import \
-    PasswordlessLoginEmailTemplateVars
+    EmailTemplateVars
 from supertokens_python.utils import is_version_gte
 from tests.utils import clean_st, reset, setup_st, sign_in_up_request, start_st
 
@@ -181,7 +181,7 @@ async def test_pless_login_backward_compatibility(driver_config_client: TestClie
     url_with_link_code = ""
     user_input_code = ""
 
-    async def create_and_send_custom_email(input_: PasswordlessLoginEmailTemplateVars, _: Dict[str, Any]):
+    async def create_and_send_custom_email(input_: EmailTemplateVars, _: Dict[str, Any]):
         nonlocal email, code_lifetime, url_with_link_code, user_input_code
         email = input_.email
         code_lifetime = input_.code_life_time
@@ -229,10 +229,10 @@ async def test_pless_login_custom_override(driver_config_client: TestClient):
     user_input_code = ""
     app_name = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[PasswordlessLoginEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: PasswordlessLoginEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, url_with_link_code, user_input_code, code_lifetime
             email = template_vars.email
             url_with_link_code = template_vars.url_with_link_code
@@ -297,7 +297,7 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
     user_input_code = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[PasswordlessLoginEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email, user_input_code
             send_raw_email_called = True
@@ -308,7 +308,7 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: PasswordlessLoginEmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
+        async def get_content_override(template_vars: EmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, user_input_code, code_lifetime
             get_content_called = True
 
@@ -338,10 +338,10 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[PasswordlessLoginEmailTemplateVars]) -> EmailDeliveryInterface[PasswordlessLoginEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: PasswordlessLoginEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email_override(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_email(template_vars, user_context)

--- a/tests/passwordless/test_smsdelivery.py
+++ b/tests/passwordless/test_smsdelivery.py
@@ -36,7 +36,7 @@ from supertokens_python.recipe import passwordless, session
 from supertokens_python.recipe.passwordless.smsdelivery.services.twilio import \
     TwilioService
 from supertokens_python.recipe.passwordless.types import \
-    PasswordlessLoginSMSTemplateVars
+    SMSTemplateVars
 from supertokens_python.utils import is_version_gte
 from tests.utils import (clean_st, reset, setup_st, sign_in_up_request_phone,
                          start_st)
@@ -256,7 +256,7 @@ async def test_pless_login_backward_compatibility(driver_config_client: TestClie
     url_with_link_code = ""
     user_input_code = ""
 
-    async def create_and_send_custom_text_message(input_: PasswordlessLoginSMSTemplateVars, _: Dict[str, Any]):
+    async def create_and_send_custom_text_message(input_: SMSTemplateVars, _: Dict[str, Any]):
         nonlocal phone, code_lifetime, url_with_link_code, user_input_code
         phone = input_.phone_number
         code_lifetime = input_.code_life_time
@@ -303,10 +303,10 @@ async def test_pless_login_custom_override(driver_config_client: TestClient):
     user_input_code = ""
     app_name = ""
 
-    def sms_delivery_override(oi: SMSDeliveryInterface[PasswordlessLoginSMSTemplateVars]):
+    def sms_delivery_override(oi: SMSDeliveryInterface[SMSTemplateVars]):
         oi_send_sms = oi.send_sms
 
-        async def send_sms(template_vars: PasswordlessLoginSMSTemplateVars, user_context: Dict[str, Any]):
+        async def send_sms(template_vars: SMSTemplateVars, user_context: Dict[str, Any]):
             nonlocal phone, url_with_link_code, user_input_code, code_lifetime
             phone = template_vars.phone_number
             url_with_link_code = template_vars.url_with_link_code
@@ -372,7 +372,7 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
     twilio_api_called = False
 
-    def twilio_service_override(oi: TwilioServiceInterface[PasswordlessLoginSMSTemplateVars]):
+    def twilio_service_override(oi: TwilioServiceInterface[SMSTemplateVars]):
 
         oi_send_raw_sms = oi.send_raw_sms
 
@@ -391,7 +391,7 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
 
             await oi_send_raw_sms(content, _user_context, from_, messaging_service_sid)
 
-        async def get_content_override(template_vars: PasswordlessLoginSMSTemplateVars, _user_context: Dict[str, Any]) -> SMSContent:
+        async def get_content_override(template_vars: SMSTemplateVars, _user_context: Dict[str, Any]) -> SMSContent:
             nonlocal get_content_called, user_input_code, code_lifetime
             get_content_called = True
 
@@ -417,10 +417,10 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
         override=twilio_service_override,
     )
 
-    def sms_delivery_override(oi: SMSDeliveryInterface[PasswordlessLoginSMSTemplateVars]) -> SMSDeliveryInterface[PasswordlessLoginSMSTemplateVars]:
+    def sms_delivery_override(oi: SMSDeliveryInterface[SMSTemplateVars]) -> SMSDeliveryInterface[SMSTemplateVars]:
         oi_send_sms = oi.send_sms
 
-        async def send_sms_override(template_vars: PasswordlessLoginSMSTemplateVars, user_context: Dict[str, Any]):
+        async def send_sms_override(template_vars: SMSTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_sms(template_vars, user_context)

--- a/tests/thirdpartyemailpassword/test_email_delivery.py
+++ b/tests/thirdpartyemailpassword/test_email_delivery.py
@@ -27,9 +27,6 @@ from supertokens_python.ingredients.emaildelivery import EmailDeliveryInterface
 from supertokens_python.ingredients.emaildelivery.types import \
     EmailDeliveryConfig, SMTPSettingsFrom, SMTPSettings, EmailContent, SMTPServiceInterface
 from supertokens_python.recipe import session, thirdpartyemailpassword
-from supertokens_python.recipe.emailpassword.types import (
-    PasswordResetEmailTemplateVars)
-from supertokens_python.recipe.emailverification.types import VerificationEmailTemplateVars
 from supertokens_python.recipe.emailpassword.types import User as EPUser
 from supertokens_python.recipe.session import SessionRecipe
 from supertokens_python.recipe.session.recipe_implementation import \
@@ -43,7 +40,7 @@ from supertokens_python.recipe.thirdpartyemailpassword.asyncio import \
 from supertokens_python.recipe.thirdpartyemailpassword.emaildelivery.services import (
     SMTPService)
 from supertokens_python.recipe.thirdpartyemailpassword.types import \
-    ThirdPartyEmailPasswordEmailTemplateVars
+    (EmailTemplateVars, VerificationEmailTemplateVars, PasswordResetEmailTemplateVars)
 from supertokens_python.recipe.thirdpartyemailpassword.types import \
     User as TPEPUser
 from tests.utils import (clean_st, email_verify_token_request, reset,
@@ -210,10 +207,10 @@ async def test_reset_password_custom_override(driver_config_client: TestClient):
     password_reset_url = ""
     app_name = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: ThirdPartyEmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, password_reset_url
             email = template_vars.user.email
             assert isinstance(template_vars, PasswordResetEmailTemplateVars)
@@ -269,7 +266,7 @@ async def test_reset_password_smtp_service(driver_config_client: TestClient):
     password_reset_url = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[ThirdPartyEmailPasswordEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email
             send_raw_email_called = True
@@ -280,7 +277,7 @@ async def test_reset_password_smtp_service(driver_config_client: TestClient):
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: ThirdPartyEmailPasswordEmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
+        async def get_content_override(template_vars: EmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, password_reset_url
             get_content_called = True
 
@@ -310,10 +307,10 @@ async def test_reset_password_smtp_service(driver_config_client: TestClient):
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]) -> EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: ThirdPartyEmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email_override(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_email(template_vars, user_context)
@@ -565,10 +562,10 @@ async def test_email_verification_custom_override(driver_config_client: TestClie
     email = ""
     email_verify_url = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: ThirdPartyEmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, email_verify_url
             email = template_vars.user.email
             assert isinstance(template_vars, VerificationEmailTemplateVars)
@@ -640,7 +637,7 @@ async def test_email_verification_smtp_service(driver_config_client: TestClient)
     email_verify_url = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[ThirdPartyEmailPasswordEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email
             send_raw_email_called = True
@@ -651,7 +648,7 @@ async def test_email_verification_smtp_service(driver_config_client: TestClient)
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: ThirdPartyEmailPasswordEmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
+        async def get_content_override(template_vars: EmailTemplateVars, _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, email_verify_url
             get_content_called = True
 
@@ -681,10 +678,10 @@ async def test_email_verification_smtp_service(driver_config_client: TestClient)
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]) -> EmailDeliveryInterface[ThirdPartyEmailPasswordEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: ThirdPartyEmailPasswordEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email_override(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
             await oi_send_email(template_vars, user_context)

--- a/tests/thirdpartypasswordless/test_emaildelivery.py
+++ b/tests/thirdpartypasswordless/test_emaildelivery.py
@@ -25,7 +25,7 @@ from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.ingredients.emaildelivery.types import (
     EmailContent, EmailDeliveryConfig, EmailDeliveryInterface,
-    SMTPSettingsFrom, SMTPServiceInterface, SMTPSettings)
+    SMTPServiceInterface, SMTPSettings, SMTPSettingsFrom)
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import (passwordless, session,
                                        thirdpartypasswordless)
@@ -39,8 +39,6 @@ from supertokens_python.recipe.session.recipe_implementation import \
     RecipeImplementation as SessionRecipeImplementation
 from supertokens_python.recipe.session.session_functions import \
     create_new_session
-from supertokens_python.recipe.thirdparty.types import \
-    ThirdPartyEmailTemplateVars
 from supertokens_python.recipe.thirdpartypasswordless.asyncio import (
     create_email_verification_token, passwordlessSigninup,
     thirdparty_sign_in_up)
@@ -49,7 +47,7 @@ from supertokens_python.recipe.thirdpartypasswordless.emaildelivery.services.smt
 from supertokens_python.recipe.thirdpartypasswordless.interfaces import \
     ThirdPartySignInUpOkResult
 from supertokens_python.recipe.thirdpartypasswordless.types import (
-    ThirdPartyPasswordlessEmailTemplateVars, User)
+    EmailTemplateVars, User, VerificationEmailTemplateVars)
 from supertokens_python.utils import is_version_gte
 from tests.utils import (clean_st, email_verify_token_request, reset, setup_st,
                          sign_in_up_request, start_st)
@@ -209,12 +207,12 @@ async def test_email_verify_custom_override(driver_config_client: TestClient):
     email = ""
     email_verify_url = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: ThirdPartyPasswordlessEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, email_verify_url
-            assert isinstance(template_vars, ThirdPartyEmailTemplateVars)
+            assert isinstance(template_vars, VerificationEmailTemplateVars)
             email = template_vars.user.email
             email_verify_url = template_vars.email_verify_link
             await oi_send_email(template_vars, user_context)
@@ -289,7 +287,7 @@ async def test_email_verify_smtp_service(driver_config_client: TestClient):
     email_verify_url = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email
             send_raw_email_called = True
@@ -300,12 +298,12 @@ async def test_email_verify_smtp_service(driver_config_client: TestClient):
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: ThirdPartyPasswordlessEmailTemplateVars,
+        async def get_content_override(template_vars: EmailTemplateVars,
                                        _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, email_verify_url
             get_content_called = True
 
-            assert isinstance(template_vars, ThirdPartyEmailTemplateVars)
+            assert isinstance(template_vars, VerificationEmailTemplateVars)
             email_verify_url = template_vars.email_verify_link
 
             return EmailContent(
@@ -331,11 +329,11 @@ async def test_email_verify_smtp_service(driver_config_client: TestClient):
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]) -> \
-            EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> \
+            EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: ThirdPartyPasswordlessEmailTemplateVars,
+        async def send_email_override(template_vars: EmailTemplateVars,
                                       user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
@@ -396,12 +394,12 @@ async def test_email_verify_for_pless_user_no_callback():
     "Email verify: test pless user shouldn't trigger callback"
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(_content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called
             send_raw_email_called = True
 
-        async def get_content_override(template_vars: ThirdPartyPasswordlessEmailTemplateVars,
+        async def get_content_override(template_vars: EmailTemplateVars,
                                        _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called
             get_content_called = True
@@ -431,11 +429,11 @@ async def test_email_verify_for_pless_user_no_callback():
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]) -> \
-            EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> \
+            EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: ThirdPartyPasswordlessEmailTemplateVars,
+        async def send_email_override(template_vars: EmailTemplateVars,
                                       user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True
@@ -597,7 +595,7 @@ async def test_pless_login_backward_compatibility(driver_config_client: TestClie
     url_with_link_code = ""
     user_input_code = ""
 
-    async def create_and_send_custom_email(input_: ThirdPartyPasswordlessEmailTemplateVars, _: Dict[str, Any]):
+    async def create_and_send_custom_email(input_: EmailTemplateVars, _: Dict[str, Any]):
         nonlocal email, code_lifetime, url_with_link_code, user_input_code
         assert isinstance(input_, PasswordlessLoginEmailTemplateVars)
         email = input_.email
@@ -646,10 +644,10 @@ async def test_pless_login_custom_override(driver_config_client: TestClient):
     user_input_code = ""
     app_name = ""
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
         oi_send_email = oi.send_email
 
-        async def send_email(template_vars: ThirdPartyPasswordlessEmailTemplateVars, user_context: Dict[str, Any]):
+        async def send_email(template_vars: EmailTemplateVars, user_context: Dict[str, Any]):
             nonlocal email, url_with_link_code, user_input_code, code_lifetime
             assert isinstance(template_vars, PasswordlessLoginEmailTemplateVars)
             email = template_vars.email
@@ -716,7 +714,7 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
     user_input_code = ""
     get_content_called, send_raw_email_called, outer_override_called = False, False, False
 
-    def smtp_service_override(oi: SMTPServiceInterface[ThirdPartyPasswordlessEmailTemplateVars]):
+    def smtp_service_override(oi: SMTPServiceInterface[EmailTemplateVars]):
         async def send_raw_email_override(content: EmailContent, _user_context: Dict[str, Any]):
             nonlocal send_raw_email_called, email, user_input_code
             send_raw_email_called = True
@@ -727,7 +725,7 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
             email = content.to_email
             # Note that we aren't calling oi.send_raw_email. So Transporter won't be used.
 
-        async def get_content_override(template_vars: ThirdPartyPasswordlessEmailTemplateVars,
+        async def get_content_override(template_vars: EmailTemplateVars,
                                        _user_context: Dict[str, Any]) -> EmailContent:
             nonlocal get_content_called, user_input_code, code_lifetime
             get_content_called = True
@@ -759,11 +757,11 @@ async def test_pless_login_smtp_service(driver_config_client: TestClient):
         override=smtp_service_override,
     )
 
-    def email_delivery_override(oi: EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]) -> \
-            EmailDeliveryInterface[ThirdPartyPasswordlessEmailTemplateVars]:
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]) -> \
+            EmailDeliveryInterface[EmailTemplateVars]:
         oi_send_email = oi.send_email
 
-        async def send_email_override(template_vars: ThirdPartyPasswordlessEmailTemplateVars,
+        async def send_email_override(template_vars: EmailTemplateVars,
                                       user_context: Dict[str, Any]):
             nonlocal outer_override_called
             outer_override_called = True


### PR DESCRIPTION
## Summary of change

Remove `<Recipe>(Email|SMS)TemplateVars` in favour of `(Email|SMS)TemplateVars` to improve DX.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 