### PR TITLE
test: Update usermetadata tests to ensure that utf8 chars are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+# Fixes
+- Fixed handling of unicode characters in usermetadata (and emails, roles, session/access token payload data)
+
 - Use [black](https://github.com/psf/black) instead of `autopep8` to format code.
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Update usermetadata tests to ensure that utf8 chars are supported.
+
 # Fixes
 - Fixed handling of unicode characters in usermetadata (and emails, roles, session/access token payload data)
 

--- a/tests/usermetadata/test_metadata.py
+++ b/tests/usermetadata/test_metadata.py
@@ -64,7 +64,7 @@ async def test_that_usermetadata_recipe_works_as_expected():
 
     TEST_USER_ID = "userId"
     TEST_METADATA: Dict[str, Any] = {
-        "role": "admin",
+        "role": "ädmin äÆ \uFDFD",  # Ensures that utf8 metadata is supported by the SDK
         "name": {"first": "John", "last": "Doe"},
     }
 


### PR DESCRIPTION
Update usermetadata tests to ensure that utf8 chars are supported

Unlike the node PR, the code in `querier.py` was already correct and didn't need to be touched. So I just added the tests to ensure that it works. 


## Related issues

-   Equivalent of https://github.com/supertokens/supertokens-node/pull/339/files

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 