### PR TITLE
test: Mark test as skipped if core version requirements are not met

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Mark tests as skipped if core version requirements are not met.
 - Use [black](https://github.com/psf/black) instead of `autopep8` to format code.
 
 ### Breaking change

--- a/tests/emailpassword/test_emailverify.py
+++ b/tests/emailpassword/test_emailverify.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Union
 from fastapi import FastAPI
 from fastapi.requests import Request
 from fastapi.testclient import TestClient
-from pytest import fixture, mark
+from pytest import fixture, mark, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.exceptions import BadInputError
 from supertokens_python.framework.fastapi import get_middleware
@@ -971,7 +971,7 @@ async def test_the_generate_token_api_with_valid_input_and_then_remove_token(
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.9"):
         # If the version less than 2.9, the recipe doesn't exist. So skip the test
-        return
+        skip()
 
     response_1 = sign_up_request(driver_config_client, "test@gmail.com", "testPass123")
     assert response_1.status_code == 200
@@ -1009,7 +1009,7 @@ async def test_the_generate_token_api_with_valid_input_verify_and_then_unverify_
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.9"):
         # If the version is less than 2.9, the recipe doesn't exist. So skip the test.
-        return
+        skip()
 
     response_1 = sign_up_request(driver_config_client, "test@gmail.com", "testPass123")
     assert response_1.status_code == 200

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from pytest import fixture, mark, raises
+from pytest import fixture, mark, raises, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.exceptions import GeneralError
 from supertokens_python.framework.fastapi import get_middleware
@@ -92,7 +92,7 @@ async def test_passwordless_otp(driver_config_client: TestClient):
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.11"):
         # If the version less than 2.11.0, passwordless OTP doesn't exist. So skip the test
-        return
+        skip()
 
     create_code_json = driver_config_client.post(
         url="/auth/signinup/code",
@@ -162,7 +162,7 @@ async def test_passworldless_delete_user_phone(driver_config_client: TestClient)
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.11"):
         # If the version less than 2.11, passwordless OTP doesn't exist. So skip the test
-        return
+        skip()
 
     create_code_json = driver_config_client.post(
         url="/auth/signinup/code",
@@ -236,7 +236,7 @@ async def test_passworldless_delete_user_email(driver_config_client: TestClient)
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.11"):
         # If the version less than 2.11, passwordless OTP doesn't exist. So skip the test
-        return
+        skip()
 
     create_code_json = driver_config_client.post(
         url="/auth/signinup/code",
@@ -312,7 +312,7 @@ async def test_passworldless_delete_user_email_and_phone_throws_error(
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.11"):
         # If the version less than 2.11, passwordless OTP doesn't exist. So skip the test
-        return
+        skip()
 
     create_code_json = driver_config_client.post(
         url="/auth/signinup/code",

--- a/tests/test_thirdpartypasswordless_delete_user.py
+++ b/tests/test_thirdpartypasswordless_delete_user.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict
 
-from pytest import fixture, mark
+from pytest import fixture, mark, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.querier import Querier
@@ -99,7 +99,7 @@ async def test_tp_passworldless_delete_user_info(driver_config_client: TestClien
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.11"):
         # If the version less than 2.11.0, passwordless OTP doesn't exist. So skip the test
-        return
+        skip()
 
     create_code_json = driver_config_client.post(
         url="/auth/signinup/code",

--- a/tests/usermetadata/test_metadata.py
+++ b/tests/usermetadata/test_metadata.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import usermetadata
@@ -60,7 +60,7 @@ async def test_that_usermetadata_recipe_works_as_expected():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.13"):
         # If the version less than 2.13, user metadata doesn't exist. So skip the test
-        return
+        skip()
 
     TEST_USER_ID = "userId"
     TEST_METADATA: Dict[str, Any] = {
@@ -114,7 +114,7 @@ async def test_usermetadata_recipe_shallow_merge():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.13"):
         # If the version less than 2.13, user metadata doesn't exist. So skip the test
-        return
+        skip()
 
     TEST_USER_ID = "userId"
 
@@ -190,7 +190,7 @@ async def test_recipe_override():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.13"):
         # If the version less than 2.13, user metadata doesn't exist. So skip the test
-        return
+        skip()
 
     res = await get_user_metadata("userId")
     assert res.metadata == {}

--- a/tests/userroles/test_add_role_to_user.py
+++ b/tests/userroles/test_add_role_to_user.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_add_new_role_to_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "userId"
     role = "role"
@@ -88,7 +88,7 @@ async def test_add_duplicate_role_to_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "userId"
     role = "role"
@@ -131,7 +131,7 @@ async def test_add_unknown_role_to_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "userId"
     role = "role"

--- a/tests/userroles/test_config.py
+++ b/tests/userroles/test_config.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import userroles
@@ -48,6 +48,6 @@ async def test_recipe_works_without_config():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     userroles.recipe.UserRolesRecipe.get_instance()

--- a/tests/userroles/test_create_new_role_or_add_permissions.py
+++ b/tests/userroles/test_create_new_role_or_add_permissions.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import userroles
@@ -49,7 +49,7 @@ async def test_create_new_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
 
@@ -76,7 +76,7 @@ async def test_create_new_role_twice():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
 
@@ -108,7 +108,7 @@ async def test_create_new_role_with_permissions():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     permissions = ["permission1"]
     role = "role"
@@ -141,7 +141,7 @@ async def test_add_permissions_to_new_role_():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     permissions = ["permission1", "permission2", "permission3"]
     role = "role"
@@ -179,7 +179,7 @@ async def test_add_duplicate_permission():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     permissions = ["permission1", "permission2"]
     role = "role"

--- a/tests/userroles/test_delete_role.py
+++ b/tests/userroles/test_delete_role.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_create_and_assign_new_role_and_delete_it():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "userId"
     roles = ["role1", "role2", "role3"]
@@ -97,7 +97,7 @@ async def test_delete_non_existent_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
 

--- a/tests/userroles/test_get_permissions_for_role.py
+++ b/tests/userroles/test_get_permissions_for_role.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.querier import Querier
 from supertokens_python.recipe import userroles
@@ -49,7 +49,7 @@ async def test_get_permission_for_a_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
     permissions = ["perm1", "perm2", "perm3"]
@@ -82,7 +82,7 @@ async def test_get_permission_for_non_existent_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
 

--- a/tests/userroles/test_get_roles_for_user.py
+++ b/tests/userroles/test_get_roles_for_user.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_get_roles_for_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "userId"
     roles = ["role1", "role2", "role3"]

--- a/tests/userroles/test_get_roles_that_have_permissions.py
+++ b/tests/userroles/test_get_roles_that_have_permissions.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_get_roles_for_that_have_permission():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     roles = ["role1", "role2", "role3"]
     permission = "permission"
@@ -84,7 +84,7 @@ async def test_get_roles_for_unknown_permission():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     permission = "permission"
 

--- a/tests/userroles/test_get_users_that_have_role.py
+++ b/tests/userroles/test_get_users_that_have_role.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_get_users_that_have_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     users = ["user1", "user2", "user3"]
     role = "role"
@@ -89,7 +89,7 @@ async def test_get_users_for_unknown_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
 

--- a/tests/userroles/test_remove_permissions_from_role.py
+++ b/tests/userroles/test_remove_permissions_from_role.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_remove_permissions_from_a_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     permissions = ["perm1", "perm2", "perm3"]
     role = "role"
@@ -87,7 +87,7 @@ async def test_remove_permissions_from_unknown_role():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     role = "role"
 

--- a/tests/userroles/test_remove_user_role.py
+++ b/tests/userroles/test_remove_user_role.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
+from pytest import mark, skip
 from supertokens_python.querier import Querier
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.recipe import userroles
@@ -50,7 +50,7 @@ async def test_remove_role_from_a_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "user_id"
     role = "role"
@@ -98,7 +98,7 @@ async def test_remove_unassigned_role_from_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "user_id"
     role = "role"
@@ -131,7 +131,7 @@ async def test_remove_non_existent_role_from_user():
     version = await Querier.get_instance().get_api_version()
     if not is_version_gte(version, "2.14"):
         # If the version less than 2.14, user roles recipe doesn't exist. So skip the test
-        return
+        skip()
 
     user_id = "user_id"
     role = "role"


### PR DESCRIPTION
## Summary of change

test: Mark test as skipped if core version requirements are not met. 

Previously we just did a `return` and it was not possible to differentiate whether a test passed successfully or got skipped.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
