### PR TITLE
fix: Clear cookies when revoke_session is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use [black](https://github.com/psf/black) instead of `autopep8` to format code.
 - Add frontend integration tests for `django2x`
 
+### Bug fix:
+
+- Clears cookies when `revoke_session` is called using the session container, even if the session did not exist from before: https://github.com/supertokens/supertokens-node/issues/343
+
 ### Breaking changes:
+- Change request arg type in session recipe functions from Any to BaseRequest.
 - Changes session function recipe interfaces to not throw an `UNAUTHORISED` error when the input is a session_handle: https://github.com/supertokens/backend/issues/83
   - `get_session_information` now returns `None` if the session does not exist.
   - `update_session_data` now returns `False` if the input `session_handle` does not exist.
@@ -71,8 +76,6 @@ init(
 )
 ```
 
-### Breaking change
-- Change request arg type in session recipe functions from Any to BaseRequest.
 
 ### Documentation
 - Add more details in the `CONTRIBUTING.md` to make it beginner friendly.

--- a/supertokens_python/recipe/session/session_class.py
+++ b/supertokens_python/recipe/session/session_class.py
@@ -22,10 +22,10 @@ class Session(SessionContainer):
     async def revoke_session(self, user_context: Union[Any, None] = None) -> None:
         if user_context is None:
             user_context = {}
-        if await self.recipe_implementation.revoke_session(
+        await self.recipe_implementation.revoke_session(
             self.session_handle, user_context
-        ):
-            self.remove_cookies = True
+        )
+        self.remove_cookies = True
 
     async def get_session_data(
         self, user_context: Union[Dict[str, Any], None] = None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,18 +12,32 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pytest import mark
 from typing import List
+
+from fastapi import FastAPI
+from fastapi.requests import Request
+from fastapi.testclient import TestClient
+from pytest import fixture, mark
+
 from supertokens_python import InputAppInfo, SupertokensConfig, init
+from supertokens_python.framework.fastapi.fastapi_middleware import get_middleware
 from supertokens_python.process_state import AllowedProcessStates, ProcessState
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session import SessionRecipe
 from supertokens_python.recipe.session.asyncio import (
+    create_new_session as asyncio_create_new_session,
+)
+from supertokens_python.recipe.session.asyncio import (
     get_all_session_handles_for_user,
     get_session_information,
+    regenerate_access_token,
+)
+from supertokens_python.recipe.session.asyncio import (
+    revoke_session as asyncio_revoke_session,
+)
+from supertokens_python.recipe.session.asyncio import (
     update_access_token_payload,
     update_session_data,
-    regenerate_access_token,
 )
 from supertokens_python.recipe.session.recipe_implementation import RecipeImplementation
 from supertokens_python.recipe.session.session_functions import (
@@ -32,7 +46,6 @@ from supertokens_python.recipe.session.session_functions import (
     refresh_session,
     revoke_session,
 )
-
 from tests.utils import clean_st, reset, setup_st, start_st
 
 
@@ -211,3 +224,70 @@ async def test_creating_many_sessions_for_one_user_and_looping():
     assert is_updated is False
     is_updated = await update_session_data("invalidHandle", {"foo": "bar"})
     assert is_updated is False
+
+
+@fixture(scope="function")
+async def driver_config_client():
+    app = FastAPI()
+    app.add_middleware(get_middleware())
+
+    @app.get("/create")
+    async def create(request: Request):  # type: ignore
+        session = await asyncio_create_new_session(request, "", {}, {})
+        session_handle = session.get_handle()
+        return {"session_handle": session_handle, "access_token": session.access_token}
+
+    @app.get("/revoke")
+    async def revoke(request: Request):  # type: ignore
+        # session_handle = request.json()["session_handle"]
+        # await asyncio_get_session(request, True, True)
+        session = await asyncio_create_new_session(request, "", {}, {})
+        session_handle = session.get_handle()
+        return {"session_handle": session_handle, "access_token": session.access_token}
+
+    return TestClient(app)
+
+
+@mark.asyncio
+async def test_signout_api_works_even_if_session_is_deleted_after_creation(
+    driver_config_client: TestClient,
+):
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="https://api.supertokens.io",
+            website_domain="supertokens.io",
+        ),
+        framework="fastapi",
+        recipe_list=[session.init(anti_csrf="VIA_TOKEN")],
+    )
+    start_st()
+
+    s = SessionRecipe.get_instance()
+    if not isinstance(s.recipe_implementation, RecipeImplementation):
+        raise Exception("Should never come here")
+    user_id = "user_id"
+
+    response = await create_new_session(s.recipe_implementation, user_id, {}, {})
+
+    session_handle = response["session"]["handle"]
+
+    revoked = await asyncio_revoke_session(session_handle)
+    assert revoked
+
+    signout_response = driver_config_client.post(
+        url="/auth/signout",
+        cookies={
+            "sAccessToken": response["accessToken"]["token"],
+            "sIdRefreshToken": response["idRefreshToken"]["token"],
+        },
+        headers={"anti-csrf": response.get("antiCsrfToken", "")},
+    )
+
+    assert signout_response.json() == {"status": "OK"}
+
+    assert (
+        signout_response.headers["set-cookie"]
+        == """sAccessToken=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/; SameSite=lax; Secure, sIdRefreshToken=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/; SameSite=lax; Secure, sRefreshToken=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/auth/session/refresh; SameSite=lax; Secure"""
+    )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,9 +25,6 @@ from supertokens_python.process_state import AllowedProcessStates, ProcessState
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session import SessionRecipe
 from supertokens_python.recipe.session.asyncio import (
-    create_new_session as asyncio_create_new_session,
-)
-from supertokens_python.recipe.session.asyncio import (
     get_all_session_handles_for_user,
     get_session_information,
     regenerate_access_token,
@@ -231,19 +228,9 @@ async def driver_config_client():
     app = FastAPI()
     app.add_middleware(get_middleware())
 
-    @app.get("/create")
-    async def create(request: Request):  # type: ignore
-        session = await asyncio_create_new_session(request, "", {}, {})
-        session_handle = session.get_handle()
-        return {"session_handle": session_handle, "access_token": session.access_token}
-
-    @app.get("/revoke")
-    async def revoke(request: Request):  # type: ignore
-        # session_handle = request.json()["session_handle"]
-        # await asyncio_get_session(request, True, True)
-        session = await asyncio_create_new_session(request, "", {}, {})
-        session_handle = session.get_handle()
-        return {"session_handle": session_handle, "access_token": session.access_token}
+    @app.get("/")
+    async def home(_request: Request):  # type: ignore
+        return {"hello": "world"}
 
     return TestClient(app)
 


### PR DESCRIPTION
## Summary of change

Clear cookies when `revoke_session` is called

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/343

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
