### PR TITLE
ci: Fix integration test failure

### DIFF
--- a/.circleci/setupAndTestWithFrontendWithDjango2x.sh
+++ b/.circleci/setupAndTestWithFrontendWithDjango2x.sh
@@ -50,9 +50,9 @@ cd supertokens-website
 git checkout $2
 cd ../project/tests/frontendIntegration/django2x
 export PYTHONPATH="${PYTHONPATH}:/root/project"
-python manage.py runserver 8080 &
+python3 manage.py runserver 8080 &
 pid=$!
-python manage.py runserver 8082 &
+python3 manage.py runserver 8082 &
 pid2=$!
 cd ../../../../supertokens-website/test/server
 npm i -d  

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
     "django": (
         [
             "django-cors-headers==3.11.0",
-            "django==3",
+            "django>=3",
             "django-stubs==1.9.0",
             "uvicorn==0.18.2",
             "python-dotenv==0.19.2",
@@ -40,7 +40,7 @@ extras_require = {
     "django2x": (
         [
             "django-cors-headers==2.0",
-            "django==2",
+            "django>=2,<3",
             "django-stubs==1.9.0",
             "python-dotenv==0.19.2",
         ]


### PR DESCRIPTION
## Summary of change

Fix integration test failure: 
- use `python3` instead of `python` (refers to 2.7 in the CI and this caused the failures)
- Fix python versions in setup.py

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 