### PR TITLE
fix: Relax dependency versions in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fix:
 
 - Clears cookies when `revoke_session` is called using the session container, even if the session did not exist from before: https://github.com/supertokens/supertokens-node/issues/343
+- Relax version requirements for `httpx`, `cryptography`, and `asgiref` to fix https://github.com/supertokens/supertokens-python/issues/207
 
 ### Breaking changes:
 - Change request arg type in session recipe functions from Any to BaseRequest.

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ test:
 dev-install:
 	pip install -r dev-requirements.txt
 
-dev-install-refresh:
-	pip3 install -e .[dev]
-
 freeze-dev-requirements:
 	pip freeze > dev-requirements.txt
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -68,7 +68,7 @@ six==1.16.0
 sniffio==1.2.0
 sqlparse==0.4.2
 starlette==0.14.2
--e git+https://github.com/supertokens/supertokens-python.git@445181dba8869f33b1a90c58778c7777d5ab560c#egg=supertokens_python
+-e git+https://github.com/supertokens/supertokens-python.git@e989cfd244dc5ed2437e49ab6b476f7e9bd16861#egg=supertokens_python
 tldextract==3.1.0
 toml==0.10.2
 tomli==2.0.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -62,7 +62,7 @@ PyYAML==5.4.1
 requests==2.25.1
 requests-file==1.5.1
 requests-mock==1.9.3
-respx==0.16.3
+respx==0.19.2
 rfc3986==1.5.0
 six==1.16.0
 sniffio==1.2.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
+aiosmtplib==1.1.6
 anyio==3.5.0
-asgiref==3.4.1
+asgiref==3.5.2
 astroid==2.9.3
 attrs==21.4.0
 black==22.3.0
@@ -8,7 +9,7 @@ cffi==1.15.0
 chardet==4.0.0
 charset-normalizer==2.0.12
 click==8.1.3
-cryptography==35.0.0
+cryptography==36.0.2
 Deprecated==1.2.13
 Django==3.2.12
 django-cors-headers==3.11.0
@@ -18,9 +19,9 @@ fastapi==0.68.1
 filelock==3.6.0
 Flask==2.0.2
 Flask-Cors==3.0.10
-h11==0.9.0
-httpcore==0.11.1
-httpx==0.15.5
+h11==0.12.0
+httpcore==0.15.0
+httpx==0.23.0
 idna==2.10
 importlib-metadata==4.11.3
 iniconfig==1.1.1
@@ -38,6 +39,7 @@ mypy-extensions==0.4.3
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 packaging==21.3
+pathspec==0.9.0
 pdoc3==0.10.0
 phonenumbers==8.12.48
 platformdirs==2.5.1
@@ -59,9 +61,8 @@ pytz==2022.1
 PyYAML==5.4.1
 requests==2.25.1
 requests-file==1.5.1
-respx==0.16.3
 requests-mock==1.9.3
-twilio==7.9.1
+respx==0.16.3
 rfc3986==1.5.0
 six==1.16.0
 sniffio==1.2.0
@@ -71,6 +72,7 @@ starlette==0.14.2
 tldextract==3.1.0
 toml==0.10.2
 tomli==2.0.1
+twilio==7.9.1
 types-pytz==2021.3.6
 types-PyYAML==6.0.5
 typing_extensions==4.1.1
@@ -80,4 +82,3 @@ uvicorn==0.18.2
 Werkzeug==2.0.3
 wrapt==1.13.3
 zipp==3.7.0
-aiosmtplib==1.1.6

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     # on changes in these frameworks
     "fastapi": (
         [
-            "respx==0.16.3",
+            "respx==0.19.2",
             "Fastapi",
             "uvicorn==0.18.2",
             "python-dotenv==0.19.2",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     keywords="",
     install_requires=[
         "PyJWT>=2.0.0 ,<2.4.0",
-        "httpx>=0.15.0 ,<0.23.0",
+        "httpx>=0.15.0 ,<0.24.0",
         "pycryptodome==3.10.*",
         "jsonschema==3.2.0",
         "tldextract==3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -104,10 +104,10 @@ setup(
         "pycryptodome==3.10.*",
         "jsonschema==3.2.0",
         "tldextract==3.1.0",
-        "asgiref==3.4.1",
+        "asgiref>=3.4.1,<4",
         "typing_extensions==4.1.1",
         "Deprecated==1.2.13",
-        "cryptography==35.0",
+        "cryptography>=35.0,<37.0",
         "phonenumbers==8.12.48",
         # flask depends on this and flask has > '2.0' for this. However, the version before 2.1.0 breaks our lib.
         "Werkzeug>=2.0 ,<2.1.0",

--- a/supertokens_python/querier.py
+++ b/supertokens_python/querier.py
@@ -81,7 +81,7 @@ class Querier:
             if Querier.__api_key is not None:
                 headers = {API_KEY_HEADER: Querier.__api_key}
             async with AsyncClient() as client:
-                return await client.get(url, headers=headers)
+                return await client.get(url, headers=headers)  # type:ignore
 
         response = await self.__send_request_helper(
             NormalisedURLPath(API_VERSION), "GET", f, len(self.__hosts)
@@ -133,7 +133,7 @@ class Querier:
 
         async def f(url: str) -> Response:
             async with AsyncClient() as client:
-                return await client.get(
+                return await client.get(  # type:ignore
                     url,
                     params=params,
                     headers=await self.__get_headers_with_api_version(path),
@@ -169,7 +169,7 @@ class Querier:
     async def send_delete_request(self, path: NormalisedURLPath):
         async def f(url: str) -> Response:
             async with AsyncClient() as client:
-                return await client.delete(
+                return await client.delete(  # type:ignore
                     url, headers=await self.__get_headers_with_api_version(path)
                 )
 

--- a/supertokens_python/recipe/thirdparty/providers/apple.py
+++ b/supertokens_python/recipe/thirdparty/providers/apple.py
@@ -155,7 +155,7 @@ class Apple(Provider):
             self.APPLE_PUBLIC_KEYS
         ) == 0:
             async with AsyncClient() as client:
-                response = await client.get(self.APPLE_PUBLIC_KEY_URL)
+                response = await client.get(self.APPLE_PUBLIC_KEY_URL)  # type:ignore
                 key_payload = response.json()
                 for key in key_payload["keys"]:
                     self.APPLE_PUBLIC_KEYS.append(RSAAlgorithm.from_jwk(key))  # type: ignore

--- a/supertokens_python/recipe/thirdparty/providers/discord.py
+++ b/supertokens_python/recipe/thirdparty/providers/discord.py
@@ -59,7 +59,7 @@ class Discord(Provider):
         access_token: str = auth_code_response["access_token"]
         headers = {"Authorization": "Bearer " + access_token}
         async with AsyncClient() as client:
-            response = await client.get(
+            response = await client.get(  # type:ignore
                 url=self.base_url + "/api/users/@me", headers=headers
             )
             user_info = response.json()

--- a/supertokens_python/recipe/thirdparty/providers/facebook.py
+++ b/supertokens_python/recipe/thirdparty/providers/facebook.py
@@ -54,7 +54,7 @@ class Facebook(Provider):
 
         params = {"access_token": access_token, "fields": "id,email", "format": "json"}
         async with AsyncClient() as client:
-            response = await client.get(
+            response = await client.get(  # type:ignore
                 url="https://graph.facebook.com/me", params=params
             )
             user_info = response.json()

--- a/supertokens_python/recipe/thirdparty/providers/github.py
+++ b/supertokens_python/recipe/thirdparty/providers/github.py
@@ -64,10 +64,10 @@ class Github(Provider):
             "Accept": "application/vnd.github.v3+json",
         }
         async with AsyncClient() as client:
-            response_user = await client.get(
+            response_user = await client.get(  # type:ignore
                 url="https://api.github.com/user", params=params, headers=headers
             )
-            response_email = await client.get(
+            response_email = await client.get(  # type:ignore
                 url="https://api.github.com/user/emails", params=params, headers=headers
             )
             user_info = response_user.json()

--- a/supertokens_python/recipe/thirdparty/providers/google.py
+++ b/supertokens_python/recipe/thirdparty/providers/google.py
@@ -59,7 +59,7 @@ class Google(Provider):
         params = {"alt": "json"}
         headers = {"Authorization": "Bearer " + access_token}
         async with AsyncClient() as client:
-            response = await client.get(
+            response = await client.get(  # type: ignore
                 url="https://www.googleapis.com/oauth2/v1/userinfo",
                 params=params,
                 headers=headers,


### PR DESCRIPTION
## Summary of change

Relax httpx, asgiref, and cryptography versions


## Related issues

-   https://github.com/supertokens/supertokens-python/issues/207

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2