### PR TITLE
fix(emailpassword): Send 400 on passing non-string email in request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Bug fix
+- Send 400 instead of 500 on invalid request body or when user passes non-string values as email ID for `/auth/signin`
+
 ## [0.10.2] - 2022-07-14
 ### Bug fix
 - Make `user_context` optional in userroles recipe syncio functions. 

--- a/supertokens_python/recipe/emailpassword/api/utils.py
+++ b/supertokens_python/recipe/emailpassword/api/utils.py
@@ -54,35 +54,28 @@ async def validate_form_or_throw_error(
 async def validate_form_fields_or_throw_error(
     config_form_fields: List[NormalisedFormField], form_fields_raw: Any
 ) -> List[FormField]:
-    try:
-        if form_fields_raw is None:
-            raise_bad_input_exception("Missing input param: formFields")
+    if form_fields_raw is None:
+        raise_bad_input_exception("Missing input param: formFields")
 
-        if not isinstance(form_fields_raw, List):
-            raise_bad_input_exception("formFields must be an array")
+    if not isinstance(form_fields_raw, List):
+        raise_bad_input_exception("formFields must be an array")
 
-        form_fields: List[FormField] = []
+    form_fields: List[FormField] = []
 
-        form_fields_list_raw: List[Dict[str, Any]] = form_fields_raw
-        for current_form_field in form_fields_list_raw:
-            if (
-                "id" not in current_form_field
-                or not isinstance(current_form_field["id"], str)
-                or "value" not in current_form_field
-            ):
-                raise_bad_input_exception(
-                    "All elements of formFields must contain an 'id' and 'value' field"
-                )
-            value = current_form_field["value"]
-            if current_form_field["id"] == FORM_FIELD_EMAIL_ID:
-                if not isinstance(value, str):
-                    raise_bad_input_exception("email value must be a string")
-                value = value.strip()
-            form_fields.append(FormField(current_form_field["id"], value))
+    form_fields_list_raw: List[Dict[str, Any]] = form_fields_raw
+    for current_form_field in form_fields_list_raw:
+        if (
+            "id" not in current_form_field
+            or not isinstance(current_form_field["id"], str)
+            or "value" not in current_form_field
+        ):
+            raise_bad_input_exception(
+                "All elements of formFields must contain an 'id' and 'value' field"
+            )
+        value = current_form_field["value"]
+        if current_form_field["id"] == FORM_FIELD_EMAIL_ID and isinstance(value, str):
+            value = value.strip()
+        form_fields.append(FormField(current_form_field["id"], value))
 
-        await validate_form_or_throw_error(form_fields, config_form_fields)
-        return form_fields
-    except Exception:
-        raise_bad_input_exception(
-            "Something seems wrong with the input formFields. Please check the request body."
-        )
+    await validate_form_or_throw_error(form_fields, config_form_fields)
+    return form_fields

--- a/supertokens_python/recipe/emailpassword/api/utils.py
+++ b/supertokens_python/recipe/emailpassword/api/utils.py
@@ -54,28 +54,35 @@ async def validate_form_or_throw_error(
 async def validate_form_fields_or_throw_error(
     config_form_fields: List[NormalisedFormField], form_fields_raw: Any
 ) -> List[FormField]:
-    if form_fields_raw is None:
-        raise_bad_input_exception("Missing input param: formFields")
+    try:
+        if form_fields_raw is None:
+            raise_bad_input_exception("Missing input param: formFields")
 
-    if not isinstance(form_fields_raw, List):
-        raise_bad_input_exception("formFields must be an array")
+        if not isinstance(form_fields_raw, List):
+            raise_bad_input_exception("formFields must be an array")
 
-    form_fields: List[FormField] = []
+        form_fields: List[FormField] = []
 
-    form_fields_list_raw: List[Dict[str, Any]] = form_fields_raw
-    for current_form_field in form_fields_list_raw:
-        if (
-            "id" not in current_form_field
-            or not isinstance(current_form_field["id"], str)
-            or "value" not in current_form_field
-        ):
-            raise_bad_input_exception(
-                "All elements of formFields must contain an 'id' and 'value' field"
-            )
-        value = current_form_field["value"]
-        if current_form_field["id"] == FORM_FIELD_EMAIL_ID:
-            value = value.strip()
-        form_fields.append(FormField(current_form_field["id"], value))
+        form_fields_list_raw: List[Dict[str, Any]] = form_fields_raw
+        for current_form_field in form_fields_list_raw:
+            if (
+                "id" not in current_form_field
+                or not isinstance(current_form_field["id"], str)
+                or "value" not in current_form_field
+            ):
+                raise_bad_input_exception(
+                    "All elements of formFields must contain an 'id' and 'value' field"
+                )
+            value = current_form_field["value"]
+            if current_form_field["id"] == FORM_FIELD_EMAIL_ID:
+                if not isinstance(value, str):
+                    raise_bad_input_exception("email value must be a string")
+                value = value.strip()
+            form_fields.append(FormField(current_form_field["id"], value))
 
-    await validate_form_or_throw_error(form_fields, config_form_fields)
-    return form_fields
+        await validate_form_or_throw_error(form_fields, config_form_fields)
+        return form_fields
+    except Exception:
+        raise_bad_input_exception(
+            "Something seems wrong with the input formFields. Please check the request body."
+        )

--- a/supertokens_python/recipe/emailpassword/utils.py
+++ b/supertokens_python/recipe/emailpassword/utils.py
@@ -70,11 +70,11 @@ async def default_password_validator(value: str) -> Union[str, None]:
     return None
 
 
-async def default_email_validator(value: str) -> Union[str, None]:
+async def default_email_validator(value: Any) -> Union[str, None]:
     # We check if the email syntax is correct
     # As per https://github.com/supertokens/supertokens-auth-react/issues/5#issuecomment-709512438
     # Regex from https://stackoverflow.com/a/46181/3867175
-    if (
+    if (not isinstance(value, str)) or (
         fullmatch(
             r'^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,'
             r"3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$",

--- a/tests/emailpassword/test_passwordreset.py
+++ b/tests/emailpassword/test_passwordreset.py
@@ -107,14 +107,15 @@ async def test_email_validation_checks_in_generate_token_API(
     )
     start_st()
 
-    response_1 = driver_config_client.post(
-        url="/auth/user/password/reset/token",
-        json={"formFields": [{"id": "email", "value": "random"}]},
-    )
+    for invalid_email in ["random", 5]:
+        res = driver_config_client.post(
+            url="/auth/user/password/reset/token",
+            json={"formFields": [{"id": "email", "value": invalid_email}]},
+        )
 
-    assert response_1.status_code == 200
-    dict_response = json.loads(response_1.text)
-    assert dict_response["status"] == "FIELD_ERROR"
+        assert res.status_code == 200
+        dict_res = json.loads(res.text)
+        assert dict_res["status"] == "FIELD_ERROR"
 
 
 @mark.asyncio


### PR DESCRIPTION
## Summary of change

Send 400 instead of 500 on invalid request body

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
