### PR TITLE
feat: Add field for smtp server username in SMTPSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -5,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+
+- Added a `username` field to the `SMTPSettings` model for passing custom SMTP server username.
 
 ## [0.11.1] - 2022-09-28
 ### Changes:

--- a/supertokens_python/ingredients/emaildelivery/services/smtp.py
+++ b/supertokens_python/ingredients/emaildelivery/services/smtp.py
@@ -59,7 +59,8 @@ class Transporter:
 
             if self.smtp_settings.password:
                 await mail.login(
-                    self.smtp_settings.from_.email, self.smtp_settings.password
+                    self.smtp_settings.username or self.smtp_settings.from_.email,
+                    self.smtp_settings.password,
                 )
 
             return mail

--- a/supertokens_python/ingredients/emaildelivery/types.py
+++ b/supertokens_python/ingredients/emaildelivery/types.py
@@ -66,12 +66,14 @@ class SMTPSettings:
         from_: SMTPSettingsFrom,
         password: Union[str, None] = None,
         secure: Union[bool, None] = None,
+        username: Union[str, None] = None,
     ) -> None:
         self.host = host
         self.from_ = from_
         self.password = password
         self.port = port
         self.secure = secure
+        self.username = username
 
 
 class EmailContent:


### PR DESCRIPTION
## Summary of change

Add smtp server login credentials in SMTPSettings

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/217

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 