### PR TITLE
fix: Repetition of root_path in supertokens mididdlware for fastapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Fix Repetition of root_path in supertokens mididdlware for fastapi [#230](https://github.com/supertokens/supertokens-python/issues/230)
+
 ## [0.11.1] - 2022-09-28
 ### Changes:
 - Email verification endpoints will now clear the session if called by a deleted/unknown user

--- a/supertokens_python/framework/fastapi/fastapi_request.py
+++ b/supertokens_python/framework/fastapi/fastapi_request.py
@@ -60,7 +60,9 @@ class FastApiRequest(BaseRequest):
         self.request.state.supertokens = None
 
     def get_path(self) -> str:
-        return self.request.url.path
+        root_path = self.request.scope.get("root_path")
+        url = self.request.url.path
+        return url[url.startswith(root_path) and len(root_path) :]
 
     async def form_data(self):
         return dict(parse_qsl((await self.request.body()).decode("utf-8")))

--- a/supertokens_python/framework/fastapi/fastapi_request.py
+++ b/supertokens_python/framework/fastapi/fastapi_request.py
@@ -62,6 +62,8 @@ class FastApiRequest(BaseRequest):
     def get_path(self) -> str:
         root_path = self.request.scope.get("root_path")
         url = self.request.url.path
+        # FastAPI seems buggy and it adds an extra root_path (if it matches):
+        # So we trim the extra root_path (from the left) from the url
         return url[url.startswith(root_path) and len(root_path) :]
 
     async def form_data(self):

--- a/supertokens_python/supertokens.py
+++ b/supertokens_python/supertokens.py
@@ -542,7 +542,7 @@ class Supertokens:
 
         if not path.startswith(Supertokens.get_instance().app_info.api_base_path):
             log_debug_message(
-                "middleware: Not handling because request path did not start with config path. Request path: %s",
+                "middleware: Not handling because request path did not start with api base path. Request path: %s",
                 path.get_as_string_dangerous(),
             )
             return None


### PR DESCRIPTION
## Summary of change

Fix repetition of root_path in supertokens mididdlware for fastapi

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/230

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 