### PR TITLE
refactor: Remove default max age from claim base classes and pass it from claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+
+### Changes:
+- Removed default `default_max_age` from session claim base classes
+- Added a 5 minute `default_max_age` to UserRoleClaim, PermissionClaim and EmailVerificationClaim
+
 ## [0.11.1] - 2022-09-28
 ### Changes:
 - Email verification endpoints will now clear the session if called by a deleted/unknown user

--- a/supertokens_python/recipe/session/claim_base_classes/boolean_claim.py
+++ b/supertokens_python/recipe/session/claim_base_classes/boolean_claim.py
@@ -11,9 +11,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from typing import Callable, Optional, Dict, Any
+from typing import Any, Callable, Dict, Optional
 
 from supertokens_python.types import MaybeAwaitable
+
 from .primitive_claim import PrimitiveClaim, PrimitiveClaimValidators
 
 
@@ -33,6 +34,9 @@ class BooleanClaim(PrimitiveClaim[bool]):
             [str, Dict[str, Any]],
             MaybeAwaitable[Optional[bool]],
         ],
+        default_max_age_in_sec: Optional[int] = None,
     ):
-        super().__init__(key, fetch_value)
-        self.validators = BooleanClaimValidators(claim=self, default_max_age_in_sec=300)
+        super().__init__(key, fetch_value, default_max_age_in_sec)
+        self.validators = BooleanClaimValidators(
+            claim=self, default_max_age_in_sec=default_max_age_in_sec
+        )

--- a/supertokens_python/recipe/session/claim_base_classes/primitive_array_claim.py
+++ b/supertokens_python/recipe/session/claim_base_classes/primitive_array_claim.py
@@ -39,7 +39,7 @@ class SCVMixin(SessionClaimValidator, Generic[_T]):
         id_: str,
         claim: SessionClaim[PrimitiveList],
         val: _T,
-        max_age_in_sec: int,
+        max_age_in_sec: Optional[int] = None,
     ):
         super().__init__(id_)
         self.claim: SessionClaim[PrimitiveList] = claim  # TODO:PrimitiveArrayClaim
@@ -171,7 +171,9 @@ class ExcludesAllSCV(SCVMixin[PrimitiveList]):
 
 class PrimitiveArrayClaimValidators(Generic[PrimitiveList]):
     def __init__(
-        self, claim: SessionClaim[PrimitiveList], default_max_age_in_sec: int
+        self,
+        claim: SessionClaim[PrimitiveList],
+        default_max_age_in_sec: Optional[int] = None,
     ) -> None:
         self.claim = claim
         self.default_max_age_in_sec = default_max_age_in_sec
@@ -234,9 +236,7 @@ class PrimitiveArrayClaim(SessionClaim[PrimitiveList], Generic[PrimitiveList]):
         super().__init__(key, fetch_value)
 
         claim = self
-        self.validators = PrimitiveArrayClaimValidators(
-            claim, default_max_age_in_sec or 300
-        )  # 5 min
+        self.validators = PrimitiveArrayClaimValidators(claim, default_max_age_in_sec)
 
     def add_to_payload_(
         self,

--- a/supertokens_python/recipe/userroles/recipe.py
+++ b/supertokens_python/recipe/userroles/recipe.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from os import environ
-from typing import List, Union, Optional, Dict, Any, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 from supertokens_python.exceptions import SuperTokensError, raise_general_exception
 from supertokens_python.framework import BaseRequest, BaseResponse
@@ -28,12 +28,12 @@ from supertokens_python.recipe.userroles.utils import validate_and_normalise_use
 from supertokens_python.recipe_module import APIHandled, RecipeModule
 from supertokens_python.supertokens import AppInfo
 
+from ...post_init_callbacks import PostSTInitCallbacks
+from ..session import SessionRecipe
+from ..session.claim_base_classes.primitive_array_claim import PrimitiveArrayClaim
 from .exceptions import SuperTokensUserRolesError
 from .interfaces import GetPermissionsForRoleOkResult
 from .utils import InputOverrideConfig
-from ..session import SessionRecipe
-from ..session.claim_base_classes.primitive_array_claim import PrimitiveArrayClaim
-from ...post_init_callbacks import PostSTInitCallbacks
 
 
 class UserRolesRecipe(RecipeModule):
@@ -142,6 +142,7 @@ class UserRolesRecipe(RecipeModule):
 class PermissionClaimClass(PrimitiveArrayClaim[List[str]]):
     def __init__(self) -> None:
         key = "st-perm"
+        default_max_age_in_sec = 300
 
         async def fetch_value(user_id: str, user_context: Dict[str, Any]) -> List[str]:
             recipe = UserRolesRecipe.get_instance()
@@ -165,7 +166,7 @@ class PermissionClaimClass(PrimitiveArrayClaim[List[str]]):
 
             return list(user_permissions)
 
-        super().__init__(key, fetch_value)
+        super().__init__(key, fetch_value, default_max_age_in_sec)
 
 
 PermissionClaim = PermissionClaimClass()
@@ -174,6 +175,7 @@ PermissionClaim = PermissionClaimClass()
 class UserRoleClaimClass(PrimitiveArrayClaim[List[str]]):
     def __init__(self) -> None:
         key = "st-role"
+        default_max_age_in_sec = 300
 
         async def fetch_value(user_id: str, user_context: Dict[str, Any]) -> List[str]:
             recipe = UserRolesRecipe.get_instance()
@@ -182,7 +184,7 @@ class UserRoleClaimClass(PrimitiveArrayClaim[List[str]]):
             )
             return res.roles
 
-        super().__init__(key, fetch_value)
+        super().__init__(key, fetch_value, default_max_age_in_sec)
 
 
 UserRoleClaim = UserRoleClaimClass()


### PR DESCRIPTION
## Summary of change

refactor: Remove default max age from claim base classes and pass it from claims

## Related issues

-   https://github.com/supertokens/supertokens-node/pull/402

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
