### PR TITLE
fix: Relax typing_extensions version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "jsonschema==3.2.0",
         "tldextract==3.1.0",
         "asgiref>=3.4.1,<4",
-        "typing_extensions==4.1.1",
+        "typing_extensions>=4.1.1,<5.0.0",
         "Deprecated==1.2.13",
         "cryptography>=35.0,<37.0",
         "phonenumbers==8.12.48",


### PR DESCRIPTION
## Summary of change

Relax the `typing_extensions` versions to be more compatible with other package requirements.

## Related issues

As per [our discord conversation](https://discord.com/channels/603466164219281420/1032111556915380305/1032160595694342186), this small change shouldn't cause any problems.