### PR TITLE
fix: Remove unused jsonschema package dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -28,7 +28,6 @@ iniconfig==1.1.1
 isort==5.10.1
 itsdangerous==2.1.2
 Jinja2==3.1.1
-jsonschema==3.2.0
 lazy-object-proxy==1.7.1
 Mako==1.2.0
 Markdown==3.3.6

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
         "PyJWT>=2.0.0 ,<2.4.0",
         "httpx>=0.15.0 ,<0.24.0",
         "pycryptodome==3.10.*",
-        "jsonschema==3.2.0",
         "tldextract==3.1.0",
         "asgiref>=3.4.1,<4",
         "typing_extensions>=4.1.1,<5.0.0",


### PR DESCRIPTION
## Summary of change

After installing of supertokens-python I found that 2 packages were downgraded. I have researched that setuptools (65.5.0 -> 65.3.0) is downgraded due to jsonschema (4.16.0 -> 3.2.0).
I then looked at the use of `jsonschema` in the code and found that after the commit 4b725c7cb2de46f46c593d07bfb73b2ae4c62a5a, which was merged in v0.5.0, it's no longer used.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
