### PR TITLE
refactor: Add to_json method in ClaimValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Add `to_json` method to `ClaimValidationError` class.
+
 ## [0.11.4] - 2022-10-21
 - Relaxes typing_extensions constraint
 - Update frontend integration test servers for /angular and /testError tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
-
+## [0.11.5] - 2022-10-27
 - Add `to_json` method to `ClaimValidationError` class.
 
 ## [0.11.4] - 2022-10-21

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.11.4",
+    version="0.11.5",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ["2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"]
-VERSION = "0.11.4"
+VERSION = "0.11.5"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/session/exceptions.py
+++ b/supertokens_python/recipe/session/exceptions.py
@@ -13,7 +13,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Union, Any, List, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from supertokens_python.exceptions import SuperTokensError
 
@@ -63,6 +63,13 @@ class ClaimValidationError:
     def __init__(self, id_: str, reason: Optional[Dict[str, Any]]):
         self.id = id_
         self.reason = reason
+
+    def to_json(self):
+        result: Dict[str, Any] = {"id": self.id}
+        if self.reason is not None:
+            result["reason"] = self.reason
+
+        return result
 
 
 def raise_invalid_claims_exception(msg: str, payload: List[ClaimValidationError]):

--- a/supertokens_python/recipe/session/utils.py
+++ b/supertokens_python/recipe/session/utils.py
@@ -278,18 +278,11 @@ async def default_invalid_claim_callback(
 ) -> BaseResponse:
     from .recipe import SessionRecipe
 
-    payload: List[Dict[str, Any]] = []
-
-    for p in claim_validation_errors:
-        res = (
-            p.__dict__.copy()
-        )  # Must be JSON serializable as it will be used in response
-        if p.reason is None:
-            res.pop("reason")
-        payload.append(res)
-
     return send_non_200_response(
-        {"message": "invalid claim", "claimValidationErrors": payload},
+        {
+            "message": "invalid claim",
+            "claimValidationErrors": [err.to_json() for err in claim_validation_errors],
+        },
         SessionRecipe.get_instance().config.invalid_claim_status_code,
         response,
     )


### PR DESCRIPTION
## Summary of change

Add `to_json` method in ClaimValidationError class

This function will be used [lambda authorization](https://supertokens.com/docs/emailpassword/serverless/with-aws-lambda/authorizer) for python

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 