### PR TITLE
fix: Invalid "type: ignore" comment

### DIFF
--- a/supertokens_python/recipe/passwordless/smsdelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/passwordless/smsdelivery/services/backward_compatibility/__init__.py
@@ -65,7 +65,7 @@ def default_create_and_send_custom_sms(app_info: AppInfo):
 
             if isinstance(e, HTTPStatusError):  # type: ignore
                 res: Response = e.response  # type: ignore
-                if res.status_code != 429:  # type: ignore (429 == Too many requests)
+                if res.status_code != 429:  # type: ignore # (429 == Too many requests)
                     data = res.json()
                     if "err" in data:
                         raise Exception(data["err"])

--- a/supertokens_python/recipe/passwordless/utils.py
+++ b/supertokens_python/recipe/passwordless/utils.py
@@ -290,7 +290,7 @@ def validate_and_normalise_user_input(
 
         return SMSDeliveryConfigWithService(sms_service, override=override)
 
-    if not isinstance(contact_config, ContactConfig):  # type: ignore user might not have linter enabled
+    if not isinstance(contact_config, ContactConfig):  # type: ignore # user might not have linter enabled
         raise ValueError("contact_config must be of type ContactConfig")
 
     if flow_type not in [
@@ -302,7 +302,7 @@ def validate_and_normalise_user_input(
             "flow_type must be one of USER_INPUT_CODE, MAGIC_LINK, USER_INPUT_CODE_AND_MAGIC_LINK"
         )
 
-    if not isinstance(override, OverrideConfig):  # type: ignore user might not have linter enabled
+    if not isinstance(override, OverrideConfig):  # type: ignore # user might not have linter enabled
         raise ValueError("override must be of type OverrideConfig")
 
     return PasswordlessConfig(


### PR DESCRIPTION
## Summary of change

Mypy doesn't support comment form of `# type: ignore {reason}`, it should be replaced with `# type: ignore # {reason}`.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

Before this changes Mypy stopped at the first invalid comment:

```shell
mypy supertokens_python/
>>> supertokens_python/recipe/passwordless/smsdelivery/services/backward_compatibility/__init__.py:68: error: Invalid "type: ignore" comment
```

after changes it will work again:

```shell
mypy supertokens_python/
>>> Found 176 errors in 64 files (checked 283 source files)
```

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2