### PR TITLE
test: Check behaviours of different variations for session revoke during session refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Add tests for different scenarios while revoking session during session refresh call
+
 ## [0.11.7] - 2022-11-21
 
 - Remove `jsonschema` from package requirements

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -350,8 +350,6 @@ async def test_revoking_session_during_refresh_with_revoke_session_with_200(
         async def refresh_post(api_options: APIOptions, user_context: Dict[str, Any]):
             s = await oi_refresh_post(api_options, user_context)
             await s.revoke_session()
-            api_options.response.set_status_code(200)  # type: ignore
-            api_options.response.set_html_content("")  # type: ignore
             return s
 
         oi.refresh_post = refresh_post


### PR DESCRIPTION

## Summary of change

Check behaviours of different variations for session revoke during session refresh


## Related issues

-   https://github.com/supertokens/supertokens-node/issues/418

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 