### PR TITLE
fix: send_email override issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## [0.11.9] - 2022-12-06
+
+-   Fixes issue where if send_email is overridden with a different email, it will reset that email.
+
 ## [0.11.8] - 2022-11-28
 
 ### Added:

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.11.8",
+    version="0.11.9",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ["2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"]
-VERSION = "0.11.8"
+VERSION = "0.11.9"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/emailpassword/emaildelivery/services/backward_compatibility/__init__.py
+++ b/supertokens_python/recipe/emailpassword/emaildelivery/services/backward_compatibility/__init__.py
@@ -17,15 +17,14 @@ from os import environ
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Union
 
 from httpx import AsyncClient
+
 from supertokens_python.ingredients.emaildelivery.types import EmailDeliveryInterface
 from supertokens_python.logger import log_debug_message
 from supertokens_python.recipe.emailpassword.interfaces import (
     EmailTemplateVars,
     RecipeInterface,
 )
-from supertokens_python.recipe.emailpassword.types import (
-    User,
-)
+from supertokens_python.recipe.emailpassword.types import User
 from supertokens_python.supertokens import AppInfo
 from supertokens_python.utils import handle_httpx_client_exceptions
 
@@ -96,6 +95,10 @@ class BackwardCompatibilityService(EmailDeliveryInterface[EmailTemplateVars]):
         if user is None:
             raise Exception("Should never come here")
 
+        # we add this here cause the user may have overridden the sendEmail function
+        # to change the input email and if we don't do this, the input email
+        # will get reset by the getUserById call above.
+        user.email = template_vars.user.email
         try:
             await self.reset_password_feature_send_email_func(
                 user, template_vars.password_reset_link, user_context

--- a/tests/emailpassword/test_emaildelivery.py
+++ b/tests/emailpassword/test_emaildelivery.py
@@ -21,33 +21,32 @@ from fastapi import FastAPI
 from fastapi.requests import Request
 from fastapi.testclient import TestClient
 from pytest import fixture, mark
+
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.ingredients.emaildelivery import EmailDeliveryInterface
 from supertokens_python.ingredients.emaildelivery.types import (
     EmailContent,
     EmailDeliveryConfig,
-    SMTPSettingsFrom,
     SMTPServiceInterface,
     SMTPSettings,
+    SMTPSettingsFrom,
 )
-from supertokens_python.recipe import emailpassword, session, emailverification
-from supertokens_python.recipe.emailpassword import (
-    InputResetPasswordUsingTokenFeature,
-)
+from supertokens_python.recipe import emailpassword, emailverification, session
+from supertokens_python.recipe.emailpassword import InputResetPasswordUsingTokenFeature
 from supertokens_python.recipe.emailpassword.emaildelivery.services import SMTPService
-from supertokens_python.recipe.emailverification.emaildelivery.services import (
-    SMTPService as EVSMTPService,
-)
 from supertokens_python.recipe.emailpassword.types import (
     EmailTemplateVars,
     PasswordResetEmailTemplateVars,
 )
 from supertokens_python.recipe.emailpassword.types import User as EPUser
+from supertokens_python.recipe.emailverification.emaildelivery.services import (
+    SMTPService as EVSMTPService,
+)
+from supertokens_python.recipe.emailverification.types import User as EVUser
 from supertokens_python.recipe.emailverification.types import (
     VerificationEmailTemplateVars,
 )
-from supertokens_python.recipe.emailverification.types import User as EVUser
 from supertokens_python.recipe.session import SessionRecipe
 from supertokens_python.recipe.session.recipe_implementation import (
     RecipeImplementation as SessionRecipeImplementation,
@@ -297,6 +296,70 @@ async def test_reset_password_custom_override(driver_config_client: TestClient):
 
         assert email == "test@example.com"
         assert password_reset_url != ""
+
+
+@mark.asyncio
+async def test_reset_password_custom_override_with_send_email_override(
+    driver_config_client: TestClient,
+):
+    "Reset password: test custom override with send email override"
+    email = ""
+    password_reset_url = ""
+
+    def email_delivery_override(oi: EmailDeliveryInterface[EmailTemplateVars]):
+        oi_send_email = oi.send_email
+
+        async def send_email(
+            template_vars: EmailTemplateVars, user_context: Dict[str, Any]
+        ):
+            template_vars.user.email = "override@example.com"
+            assert isinstance(template_vars, PasswordResetEmailTemplateVars)
+            await oi_send_email(template_vars, user_context)
+
+        oi.send_email = send_email
+        return oi
+
+    async def custom_create_and_send_custom_email(
+        user: EPUser, password_reset_link: str, _: Dict[str, Any]
+    ):
+        nonlocal email, password_reset_url
+        email = user.email
+        password_reset_url = password_reset_link
+
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="ST",
+            api_domain="http://api.supertokens.io",
+            website_domain="http://supertokens.io",
+            api_base_path="/auth",
+        ),
+        framework="fastapi",
+        recipe_list=[
+            emailpassword.init(
+                email_delivery=EmailDeliveryConfig(
+                    service=None,
+                    override=email_delivery_override,
+                ),
+                reset_password_using_token_feature=emailpassword.InputResetPasswordUsingTokenFeature(
+                    create_and_send_custom_email=custom_create_and_send_custom_email
+                ),
+            ),
+            session.init(),
+        ],
+    )
+    start_st()
+
+    sign_up_request(driver_config_client, "test@example.com", "1234abcd")
+
+    resp = reset_password_request(
+        driver_config_client, "test@example.com", use_server=True
+    )
+
+    assert resp.status_code == 200
+
+    assert email == "override@example.com"
+    assert password_reset_url != ""
 
 
 @mark.asyncio


### PR DESCRIPTION
## Summary of change

If the user is overriding the send_email function in emailpassword recipe to change the input email, their change will not get reflected since our implementation calls the get_user_by_id function which will reset their changed email.

So we reassign the input email to the result of calling getUserById

## Related issues

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR
