### PR TITLE
fix: Respond with field error on existing email id in signup api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## [0.11.10] - 2022-12-12
+
+-   Fixes issue of sign up API not sending a `FIELD_ERROR` response in case of duplicate email: https://github.com/supertokens/supertokens-python/issues/264
+
 ## [0.11.9] - 2022-12-06
 
 -   Fixes issue where if send_email is overridden with a different email, it will reset that email.

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.11.9",
+    version="0.11.10",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ["2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"]
-VERSION = "0.11.9"
+VERSION = "0.11.10"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/emailpassword/api/signup.py
+++ b/supertokens_python/recipe/emailpassword/api/signup.py
@@ -15,6 +15,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..exceptions import raise_form_field_exception
+from supertokens_python.recipe.emailpassword.interfaces import (
+    SignUpOkResult,
+    SignUpPostEmailAlreadyExistsError,
+)
+from supertokens_python.types import GeneralErrorResponse
+from ..types import ErrorFormField
+
 if TYPE_CHECKING:
     from supertokens_python.recipe.emailpassword.interfaces import (
         APIOptions,
@@ -43,4 +51,17 @@ async def handle_sign_up_api(api_implementation: APIInterface, api_options: APIO
         form_fields, api_options, user_context
     )
 
-    return send_200_response(response.to_json(), api_options.response)
+    if isinstance(response, SignUpOkResult):
+        return send_200_response(response.to_json(), api_options.response)
+    if isinstance(response, GeneralErrorResponse):
+        return send_200_response(response.to_json(), api_options.response)
+    if isinstance(response, SignUpPostEmailAlreadyExistsError):
+        return raise_form_field_exception(
+            "EMAIL_ALREADY_EXISTS_ERROR",
+            [
+                ErrorFormField(
+                    id="email",
+                    error="This email already exists. Please sign in instead.",
+                )
+            ],
+        )

--- a/supertokens_python/recipe/emailpassword/exceptions.py
+++ b/supertokens_python/recipe/emailpassword/exceptions.py
@@ -13,7 +13,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, NoReturn
 
 from supertokens_python.exceptions import SuperTokensError
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from .types import ErrorFormField
 
 
-def raise_form_field_exception(msg: str, form_fields: List[ErrorFormField]):
+def raise_form_field_exception(msg: str, form_fields: List[ErrorFormField]) -> NoReturn:
     raise FieldError(msg, form_fields)
 
 

--- a/tests/emailpassword/test_signup.py
+++ b/tests/emailpassword/test_signup.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from fastapi import FastAPI
+import json
+from fastapi.testclient import TestClient
+from pytest import fixture, mark
+from supertokens_python import init
+from supertokens_python.framework.fastapi import get_middleware
+from supertokens_python.recipe import emailpassword, session
+from tests.utils import (
+    get_st_init_args,
+    setup_function,
+    start_st,
+    teardown_function,
+    sign_up_request,
+)
+
+_ = setup_function  # type: ignore
+_ = teardown_function  # type: ignore
+
+pytestmark = mark.asyncio
+
+
+@fixture(scope="function")
+async def app():
+    app = FastAPI()
+    app.add_middleware(get_middleware())
+
+    return TestClient(app)
+
+
+async def test_field_error_on_existing_email_signup(app: TestClient):
+    init_args = get_st_init_args([emailpassword.init(), session.init()])
+    init(**init_args)
+    start_st()
+
+    response = json.loads(sign_up_request(app, "random@gmail.com", "validpass123").text)
+    assert response["status"] == "OK"
+
+    response = json.loads(sign_up_request(app, "random@gmail.com", "validpass123").text)
+    assert response == {
+        "status": "FIELD_ERROR",
+        "formFields": [
+            {
+                "id": "email",
+                "error": "This email already exists. Please sign in instead.",
+            }
+        ],
+    }


### PR DESCRIPTION
## Summary of change

Respond with field error on existing email id in signup api

## Related issues

-  https://github.com/supertokens/supertokens-python/issues/264

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 