### PR TITLE
fix: Import SignUpPostOkResult instead of SignUpOkResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## [0.11.10] - 2022-12-12
+
+- Respond with field error on existing email id in signup api
+
 ## [0.11.9] - 2022-12-06
 
 -   Fixes issue where if send_email is overridden with a different email, it will reset that email.

--- a/supertokens_python/recipe/emailpassword/api/signup.py
+++ b/supertokens_python/recipe/emailpassword/api/signup.py
@@ -15,12 +15,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..exceptions import raise_form_field_exception
-from supertokens_python.recipe.emailpassword.interfaces import (
-    SignUpOkResult,
-    SignUpPostEmailAlreadyExistsError,
-)
+from supertokens_python.recipe.emailpassword.interfaces import SignUpPostOkResult
 from supertokens_python.types import GeneralErrorResponse
+
+from ..exceptions import raise_form_field_exception
 from ..types import ErrorFormField
 
 if TYPE_CHECKING:
@@ -51,17 +49,17 @@ async def handle_sign_up_api(api_implementation: APIInterface, api_options: APIO
         form_fields, api_options, user_context
     )
 
-    if isinstance(response, SignUpOkResult):
+    if isinstance(response, SignUpPostOkResult):
         return send_200_response(response.to_json(), api_options.response)
     if isinstance(response, GeneralErrorResponse):
         return send_200_response(response.to_json(), api_options.response)
-    if isinstance(response, SignUpPostEmailAlreadyExistsError):
-        return raise_form_field_exception(
-            "EMAIL_ALREADY_EXISTS_ERROR",
-            [
-                ErrorFormField(
-                    id="email",
-                    error="This email already exists. Please sign in instead.",
-                )
-            ],
-        )
+
+    return raise_form_field_exception(
+        "EMAIL_ALREADY_EXISTS_ERROR",
+        [
+            ErrorFormField(
+                id="email",
+                error="This email already exists. Please sign in instead.",
+            )
+        ],
+    )


### PR DESCRIPTION
## Summary of change

Import SignUpPostOkResult instead of SignUpOkResult

## Related issues

- https://github.com/supertokens/supertokens-python/issues/264
- https://github.com/supertokens/supertokens-python/pull/265

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 