### PR TITLE
Fix problem with wrong "expires" format

### DIFF
--- a/supertokens_python/framework/django/django_response.py
+++ b/supertokens_python/framework/django/django_response.py
@@ -50,9 +50,7 @@ class DjangoResponse(BaseResponse):
         self.response.set_cookie(
             key=key,
             value=value,
-            expires=datetime.fromtimestamp(ceil(expires / 1000)).strftime(
-                "%A, %B %d, %Y %H:%M:%S"
-            ),
+            expires=datetime.fromtimestamp(ceil(expires / 1000)),
             path=path,
             domain=domain,
             secure=secure,


### PR DESCRIPTION
The format passed to strftime is incorrect and does not work with some browsers. It's better to pass datetime object to Django, which will handle formatting date correctly

## Summary of change

I removed the `.strftime(...)` part converting datetime to string in incorrect way when passed to the function `set_cookie` in Django `HttpResponse` object

As a side-effect of the change, Django will add "Max-Age" parameter to every "Set-Cookie" header. I believe it's not a problem, however, to change this behavior, one should add `strftime(...)` back with correct date format

## Related issues

-   [#267 ](https://github.com/supertokens/supertokens-python/issues/267)

## Test Plan

I've applied the change and tested it with my server. The cookies are sent with correct date format now. Sign out now works for the browser where it didn't work before (any Webkit-based browser, Gnome Web for example).

![obraz](https://user-images.githubusercontent.com/9148251/209116792-a637736d-38be-4dc5-ae29-aa8fe32ad064.png)


## Documentation changes

Not relevant

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

