### PR TITLE
fix: Django cookie expiry time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+-  Fix django cookie expiry time format to make it consistent with other frameworks
+
 ## [0.11.11] - 2022-12-26
 
 -   Updates dashboard version

--- a/supertokens_python/framework/django/django_response.py
+++ b/supertokens_python/framework/django/django_response.py
@@ -51,7 +51,7 @@ class DjangoResponse(BaseResponse):
             key=key,
             value=value,
             expires=datetime.fromtimestamp(ceil(expires / 1000)).strftime(
-                "%A, %B %d, %Y %H:%M:%S"
+                "%a, %d %b %Y %H:%M:%S GMT"
             ),
             path=path,
             domain=domain,

--- a/tests/Django/test_django.py
+++ b/tests/Django/test_django.py
@@ -16,6 +16,7 @@ import json
 from inspect import isawaitable
 from typing import Any, Dict, Union
 
+from datetime import datetime
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import RequestFactory, TestCase
 from supertokens_python import InputAppInfo, SupertokensConfig, init
@@ -251,6 +252,13 @@ class SupertokensTest(TestCase):
         assert len(cookies["sAccessToken"]["value"]) > 0
         assert len(cookies["sIdRefreshToken"]["value"]) > 0
         assert len(cookies["sRefreshToken"]["value"]) > 0
+
+        try:
+            datetime.strptime(
+                cookies["sAccessToken"]["expires"], "%a, %d %b %Y %H:%M:%S GMT"
+            )
+        except ValueError:
+            assert False, "cookies expiry time doesn't have the correct format"
 
         my_middleware = middleware(handle_view)
         request = self.factory.get("/handle", {"user_id": "user_id"})


### PR DESCRIPTION
## Summary of change

Django cookie expiry time format is incorrect and inconsistent compared to other frameworks. Thankfully, @aprilis spotted and reported this issue. 

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/267

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 