### PR TITLE
fix: Make flask response consistent with other frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Add missing `original` attribute to flask response and remove logic for cases where `response` is `None`
+
 ## [0.11.12] - 2022-12-27
 -  Fix django cookie expiry time format to make it consistent with other frameworks: https://github.com/supertokens/supertokens-python/issues/267
 

--- a/supertokens_python/framework/flask/flask_response.py
+++ b/supertokens_python/framework/flask/flask_response.py
@@ -23,6 +23,7 @@ class FlaskResponse(BaseResponse):
     def __init__(self, response: Response):
         super().__init__({})
         self.response = response
+        self.original = response
         self.headers: List[Any] = []
         self.response_sent = False
         self.status_set = False
@@ -44,53 +45,22 @@ class FlaskResponse(BaseResponse):
         httponly: bool = False,
         samesite: str = "lax",
     ):
-        from werkzeug.http import dump_cookie
-
-        if self.response is None:
-            cookie = dump_cookie(
-                key,
-                value=value,
-                expires=int(expires / 1000),
-                path=path,
-                domain=domain,
-                secure=secure,
-                httponly=httponly,
-                samesite=samesite,
-            )
-            self.headers.append(("Set-Cookie", cookie))
-        else:
-            self.response.set_cookie(
-                key,
-                value=value,
-                expires=expires / 1000,
-                path=path,
-                domain=domain,
-                secure=secure,
-                httponly=httponly,
-                samesite=samesite,
-            )
+        self.response.set_cookie(
+            key,
+            value=value,
+            expires=expires / 1000,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
+        )
 
     def set_header(self, key: str, value: str):
-        if self.response is None:
-            # TODO in the future the headrs must be validated..
-            # if not isinstance(value, str):
-            #     raise TypeError("Value should be unicode.")
-            if "\n" in value or "\r" in value:
-                raise ValueError(
-                    "Detected newline in header value.  This is "
-                    "a potential security problem"
-                )
-            self.headers.append((key, value))
-        else:
-            self.response.headers.add(key, value)
+        self.response.headers.add(key, value)
 
     def get_header(self, key: str) -> Union[None, str]:
-        if self.response is not None:
-            return self.response.headers.get(key)
-        for value in self.headers:
-            if value[0] == key:
-                return value[1]
-        return None
+        return self.response.headers.get(key)
 
     def set_status_code(self, status_code: int):
         if not self.status_set:
@@ -99,8 +69,6 @@ class FlaskResponse(BaseResponse):
             self.status_set = True
 
     def get_headers(self):
-        if self.response is None:
-            return self.headers
         return self.response.headers
 
     def set_json_content(self, content: Dict[str, Any]):


### PR DESCRIPTION
## Summary of change

Add missing `original` attribute to flask response and remove logic for cases where `response` is `None`

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 