### PR TITLE
fix: Relax werkzeug version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Remove constraints on `werkzeug` version
+
 ### Breaking changes
 
 -   The frontend SDK should be updated to a version supporting the header-based sessions!

--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,6 @@ setup(
         "Deprecated==1.2.13",
         "cryptography>=35.0,<37.0",
         "phonenumbers==8.12.48",
-        # flask depends on this and flask has > '2.0' for this. However, the version before 2.1.0 breaks our lib.
-        "Werkzeug>=2.0 ,<2.1.0",
         "twilio==7.9.1",
         "aiosmtplib==1.1.6",
     ],


### PR DESCRIPTION
## Summary of change

Relax werkzeug version constraints

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 