### PR TITLE
fix: Failing supertokens-website frontendIntegration tests

### DIFF
--- a/supertokens_python/recipe/session/with_jwt/recipe_implementation.py
+++ b/supertokens_python/recipe/session/with_jwt/recipe_implementation.py
@@ -156,7 +156,7 @@ def get_recipe_implementation_with_jwt(
             jwt=existing_jwt, options={"verify_signature": False, "verify_exp": False}
         )
 
-        if decoded_payload is None:
+        if decoded_payload is None or decoded_payload.get("exp") is None:
             raise Exception("Error reading JWT from session")
 
         jwt_expiry = 1

--- a/supertokens_python/recipe/session/with_jwt/session_class.py
+++ b/supertokens_python/recipe/session/with_jwt/session_class.py
@@ -67,7 +67,7 @@ def get_session_with_jwt(
             jwt=existing_jwt, options={"verify_signature": False, "verify_exp": False}
         )
 
-        if decoded_payload is None:
+        if decoded_payload is None or decoded_payload.get("exp") is None:
             raise Exception("Error reading JWT from session")
 
         jwt_expiry = 1

--- a/tests/frontendIntegration/django2x/mysite/settings.py
+++ b/tests/frontendIntegration/django2x/mysite/settings.py
@@ -51,11 +51,12 @@ CORS_ALLOW_METHODS = [
     "PUT",
 ]
 
-CORS_ALLOW_HEADERS: List[str] = list(default_headers) + [  # type: ignore
+CORS_ALLOW_HEADERS: List[str] = list(default_headers) + [
     "Content-Type",
     "rid",
     "fdi-version",
     "anti-csrf",
+    "st-auth-mode",
 ]
 
 # Application definition

--- a/tests/frontendIntegration/django2x/polls/views.py
+++ b/tests/frontendIntegration/django2x/polls/views.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, Union
 
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
+from django.conf import settings
+from supertokens_python import get_all_cors_headers
 from supertokens_python import InputAppInfo, Supertokens, SupertokensConfig, init
 from supertokens_python.framework import BaseRequest, BaseResponse
 from supertokens_python.recipe import session
@@ -308,6 +310,9 @@ def config(
             ],
             telemetry=False,
         )
+
+    for header in get_all_cors_headers():
+        assert header in settings.CORS_ALLOW_HEADERS
 
 
 config(True, False, None)

--- a/tests/frontendIntegration/django3x/mysite/settings.py
+++ b/tests/frontendIntegration/django3x/mysite/settings.py
@@ -50,11 +50,12 @@ CORS_ALLOW_METHODS = [
     "PUT",
 ]
 
-CORS_ALLOW_HEADERS: List[str] = list(default_headers) + [  # type: ignore
+CORS_ALLOW_HEADERS: List[str] = list(default_headers) + [
     "Content-Type",
     "rid",
     "fdi-version",
     "anti-csrf",
+    "st-auth-mode",
 ]
 
 # Application definition

--- a/tests/frontendIntegration/django3x/polls/views.py
+++ b/tests/frontendIntegration/django3x/polls/views.py
@@ -25,6 +25,8 @@ from typing import Any
 
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
+from django.conf import settings
+from supertokens_python import get_all_cors_headers
 from supertokens_python import InputAppInfo, Supertokens, SupertokensConfig, init
 from supertokens_python.framework import BaseRequest, BaseResponse
 from supertokens_python.recipe import session
@@ -315,6 +317,9 @@ def config(
             ],
             telemetry=False,
         )
+
+    for header in get_all_cors_headers():
+        assert header in settings.CORS_ALLOW_HEADERS
 
 
 config(True, False, None)


### PR DESCRIPTION
## Summary of change

Fix failing supertokens-website frontendIntegration tests for Django

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 