### PR TITLE
fix: Run npm i after installing supertokens node to fix tests

### DIFF
--- a/.circleci/setupAndTestWithAuthReact.sh
+++ b/.circleci/setupAndTestWithAuthReact.sh
@@ -51,8 +51,8 @@ git checkout $2
 npm run init > /dev/null
 (cd ./examples/for-tests && npm run link) # this is there because in linux machine, postinstall in npm doesn't work..
 cd ./test/server/
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i  
 cd ../../../project/tests/auth-react/fastapi-server
 export PYTHONPATH="${PYTHONPATH}:/root/project"
 uvicorn app:app --host 0.0.0.0 --port 8083 &

--- a/.circleci/setupAndTestWithAuthReactWithDjango.sh
+++ b/.circleci/setupAndTestWithAuthReactWithDjango.sh
@@ -51,8 +51,8 @@ git checkout $2
 npm run init > /dev/null
 (cd ./examples/for-tests && npm run link) # this is there because in linux machine, postinstall in npm doesn't work..
 cd ./test/server/
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i
 cd ../../../project/tests/auth-react/django3x
 export PYTHONPATH="${PYTHONPATH}:/root/project"
 uvicorn mysite.asgi:application --port 8083 &

--- a/.circleci/setupAndTestWithAuthReactWithFlask.sh
+++ b/.circleci/setupAndTestWithAuthReactWithFlask.sh
@@ -51,8 +51,8 @@ git checkout $2
 npm run init > /dev/null
 (cd ./examples/for-tests && npm run link) # this is there because in linux machine, postinstall in npm doesn't work..
 cd ./test/server/
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i
 cd ../../../project/tests/auth-react/flask-server
 export PYTHONPATH="${PYTHONPATH}:/root/project"
 python3 app.py --port 8083 &

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -55,10 +55,10 @@ pid=$!
 uvicorn app:app --host 0.0.0.0 --port 8082 &
 pid2=$!
 cd ../../../../supertokens-website/test/server
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i
 cd ../../
-npm i -d  
+npm i 
 SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontendWithDjango.sh
+++ b/.circleci/setupAndTestWithFrontendWithDjango.sh
@@ -55,10 +55,10 @@ pid=$!
 uvicorn mysite.asgi:application --port 8082 &
 pid2=$!
 cd ../../../../supertokens-website/test/server
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i
 cd ../../
-npm i -d  
+npm i
 SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontendWithDjango2x.sh
+++ b/.circleci/setupAndTestWithFrontendWithDjango2x.sh
@@ -55,10 +55,10 @@ pid=$!
 gunicorn mysite.wsgi --bind 0.0.0.0:8082 &
 pid2=$!
 cd ../../../../supertokens-website/test/server
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i
 cd ../../
-npm i -d  
+npm i
 SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontendWithFlask.sh
+++ b/.circleci/setupAndTestWithFrontendWithFlask.sh
@@ -55,10 +55,10 @@ pid=$!
 python3 app.py --port 8082 &
 pid2=$!
 cd ../../../../supertokens-website/test/server
-npm i -d  
 npm i git+https://github.com:supertokens/supertokens-node.git#$3  
+npm i
 cd ../../
-npm i -d  
+npm i
 SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
 if [[ $? -ne 0 ]]
 then


### PR DESCRIPTION
## Summary of change

Run npm i after installing supertokens node to fix tests

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 