### PR TITLE
chores: Use header based auth in examples

### DIFF
--- a/examples/with-django/with-thirdpartyemailpassword/project/settings.py
+++ b/examples/with-django/with-thirdpartyemailpassword/project/settings.py
@@ -65,7 +65,7 @@ init(
     framework="django",
     mode="wsgi",
     recipe_list=[
-        session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+        session.init(),
         emailverification.init("REQUIRED"),
         thirdpartyemailpassword.init(
             providers=[

--- a/examples/with-fastapi/with-thirdpartyemailpassword/main.py
+++ b/examples/with-fastapi/with-thirdpartyemailpassword/main.py
@@ -55,7 +55,7 @@ init(
     ),
     framework="fastapi",
     recipe_list=[
-        session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+        session.init(),
         emailverification.init("REQUIRED"),
         thirdpartyemailpassword.init(
             providers=[

--- a/examples/with-flask/with-thirdpartyemailpassword/app.py
+++ b/examples/with-flask/with-thirdpartyemailpassword/app.py
@@ -48,7 +48,7 @@ init(
     ),
     framework="flask",
     recipe_list=[
-        session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+        session.init(),
         emailverification.init("REQUIRED"),
         thirdpartyemailpassword.init(
             providers=[


### PR DESCRIPTION
## Summary of change

Use header based auth in examples. Previously, it was forcing to use `cookies`. Now using the default (i.e. headers)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [] Changelog has been updated => Not required since not changing the lib
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 