### PR TITLE
fix: Update access token cookie expiry logic and add comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## [0.12.2] - 2023-02-23
+- Fix expiry time of access token cookie.
+
+
 ## [0.12.1] - 2023-02-06
 
 -   Email template updates

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.12.1",
+    version="0.12.2",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ["2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"]
-VERSION = "0.12.1"
+VERSION = "0.12.2"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/framework/fastapi/fastapi_request.py
+++ b/supertokens_python/framework/fastapi/fastapi_request.py
@@ -45,6 +45,8 @@ class FastApiRequest(BaseRequest):
         return self.request.method
 
     def get_cookie(self, key: str) -> Union[str, None]:
+        # Note: Unlike other frameworks, FastAPI wraps the value in quotes in Set-Cookie header
+        # It also takes care of escaping the quotes while fetching the value
         return self.request.cookies.get(key)
 
     def get_header(self, key: str) -> Union[str, None]:

--- a/supertokens_python/framework/fastapi/fastapi_response.py
+++ b/supertokens_python/framework/fastapi/fastapi_response.py
@@ -52,31 +52,19 @@ class FastApiResponse(BaseResponse):
         # Note: For FastAPI response object, the expires value
         # doesn't mean the absolute time in ms, but the duration in seconds
         # So we need to convert our absolute expiry time (ms) to a duration (seconds)
-        if domain is None:
-            # we do ceil because if we do floor, we tests may fail where the access
-            # token lifetime is set to 1 second
-            self.response.set_cookie(
-                key=key,
-                value=value,
-                expires=ceil((expires - get_timestamp_ms()) / 1000),
-                path=path,
-                secure=secure,
-                httponly=httponly,
-                samesite=samesite,
-            )
-        else:
-            # we do ceil because if we do floor, we tests may fail where the access
-            # token lifetime is set to 1 second
-            self.response.set_cookie(
-                key=key,
-                value=value,
-                expires=ceil((expires - get_timestamp_ms()) / 1000),
-                path=path,
-                domain=domain,
-                secure=secure,
-                httponly=httponly,
-                samesite=samesite,
-            )
+
+        # we do ceil because if we do floor, we tests may fail where the access
+        # token lifetime is set to 1 second
+        self.response.set_cookie(
+            key=key,
+            value=value,  # Note: Unlike other frameworks, FastAPI wraps the value in quotes in Set-Cookie header
+            expires=ceil((expires - get_timestamp_ms()) / 1000),
+            path=path,
+            domain=domain,  # type: ignore # starlette didn't set domain as optional type but their default value is None anyways
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
+        )
 
     def set_header(self, key: str, value: str):
         self.response.headers[key] = value

--- a/supertokens_python/framework/fastapi/fastapi_response.py
+++ b/supertokens_python/framework/fastapi/fastapi_response.py
@@ -13,10 +13,10 @@
 # under the License.
 import json
 from math import ceil
-from time import time
 from typing import Any, Dict, Optional
 
 from supertokens_python.framework.response import BaseResponse
+from supertokens_python.utils import get_timestamp_ms
 
 
 class FastApiResponse(BaseResponse):
@@ -49,13 +49,16 @@ class FastApiResponse(BaseResponse):
         httponly: bool = False,
         samesite: str = "lax",
     ):
+        # Note: For FastAPI response object, the expires value
+        # doesn't mean the absolute time in ms, but the duration in seconds
+        # So we need to convert our absolute expiry time (ms) to a duration (seconds)
         if domain is None:
             # we do ceil because if we do floor, we tests may fail where the access
             # token lifetime is set to 1 second
             self.response.set_cookie(
                 key=key,
                 value=value,
-                expires=ceil((expires - int(time() * 1000)) / 1000),
+                expires=ceil((expires - get_timestamp_ms()) / 1000),
                 path=path,
                 secure=secure,
                 httponly=httponly,
@@ -67,7 +70,7 @@ class FastApiResponse(BaseResponse):
             self.response.set_cookie(
                 key=key,
                 value=value,
-                expires=ceil((expires - int(time() * 1000)) / 1000),
+                expires=ceil((expires - get_timestamp_ms()) / 1000),
                 path=path,
                 domain=domain,
                 secure=secure,

--- a/supertokens_python/recipe/session/recipe_implementation.py
+++ b/supertokens_python/recipe/session/recipe_implementation.py
@@ -254,7 +254,7 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
         # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
         # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
         # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
-        # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
+        # Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
         response_mutators.append(
             token_response_mutator(
                 self.config,
@@ -269,7 +269,9 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
                 self.config,
                 "refresh",
                 new_refresh_token_info["token"],
-                new_refresh_token_info["expiry"],
+                new_refresh_token_info[
+                    "expiry"
+                ],  # This comes from the core and is 100 days
                 new_session.transfer_method,
             )
         )
@@ -466,7 +468,7 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
             # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
             # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
             # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
-            # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
+            # Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
             session.response_mutators.append(
                 token_response_mutator(
                     self.config,
@@ -617,7 +619,7 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
                 # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                 # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
                 # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
-                # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
+                # Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
                 response_mutators.append(
                     token_response_mutator(
                         self.config,
@@ -633,7 +635,9 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
                         self.config,
                         "refresh",
                         new_refresh_token_info["token"],
-                        new_refresh_token_info["expiry"],
+                        new_refresh_token_info[
+                            "expiry"
+                        ],  # This comes from the core and is 100 days
                         session.transfer_method,
                     )
                 )

--- a/supertokens_python/recipe/session/recipe_implementation.py
+++ b/supertokens_python/recipe/session/recipe_implementation.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 from supertokens_python.framework import BaseRequest
@@ -33,14 +32,14 @@ from ...types import MaybeAwaitable
 from . import session_functions
 from .access_token import validate_access_token_structure
 from .cookie_and_header import (
+    anti_csrf_response_mutator,
+    clear_session_response_mutator,
+    front_token_response_mutator,
     get_anti_csrf_header,
     get_rid_header,
     get_token,
-    token_response_mutator,
-    front_token_response_mutator,
-    anti_csrf_response_mutator,
     set_cookie_response_mutator,
-    clear_session_response_mutator,
+    token_response_mutator,
 )
 from .exceptions import (
     TokenTheftError,
@@ -50,12 +49,12 @@ from .exceptions import (
 )
 from .interfaces import (
     AccessTokenObj,
-    ResponseMutator,
     ClaimsValidationResult,
     GetClaimValueOkResult,
     JSONObject,
     RecipeInterface,
     RegenerateAccessTokenOkResult,
+    ResponseMutator,
     SessionClaim,
     SessionClaimValidator,
     SessionDoesNotExistError,
@@ -64,13 +63,17 @@ from .interfaces import (
 )
 from .jwt import ParsedJWTInfo, parse_jwt_without_signature_verification
 from .session_class import Session
-from .utils import SessionConfig, TokenTransferMethod, validate_claims_in_payload
+from .utils import (
+    HUNDRED_YEARS_IN_MS,
+    SessionConfig,
+    TokenTransferMethod,
+    validate_claims_in_payload,
+)
 
 if TYPE_CHECKING:
     from typing import List, Union
     from supertokens_python import AppInfo
     from supertokens_python.querier import Querier
-
 
 from .constants import available_token_transfer_methods
 from .interfaces import SessionContainer
@@ -248,12 +251,16 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
                 new_session.access_token_payload,
             )
         )
+        # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+        # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+        # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+        # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
         response_mutators.append(
             token_response_mutator(
                 self.config,
                 "access",
                 new_access_token_info["token"],
-                int(datetime.now().timestamp()) + 3153600000000,
+                get_timestamp_ms() + HUNDRED_YEARS_IN_MS,
                 new_session.transfer_method,
             )
         )
@@ -456,12 +463,16 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
                     session.access_token_payload,
                 )
             )
+            # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+            # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+            # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+            # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
             session.response_mutators.append(
                 token_response_mutator(
                     self.config,
                     "access",
                     session.access_token,
-                    int(datetime.now().timestamp()) + 3153600000000,
+                    get_timestamp_ms() + HUNDRED_YEARS_IN_MS,
                     session.transfer_method,
                 )
             )
@@ -603,12 +614,16 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
                         session.access_token_payload,
                     )
                 )
+                # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+                # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+                # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+                # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                 response_mutators.append(
                     token_response_mutator(
                         self.config,
                         "access",
                         new_access_token_info["token"],
-                        int(datetime.now().timestamp()) + 3153600000000,
+                        get_timestamp_ms() + HUNDRED_YEARS_IN_MS,  # 100 years
                         session.transfer_method,
                     )
                 )

--- a/supertokens_python/recipe/session/session_class.py
+++ b/supertokens_python/recipe/session/session_class.py
@@ -99,7 +99,7 @@ class Session(SessionContainer):
             # We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
             # This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
             # Even if the token is expired the presence of the token indicates that the user could have a valid refresh
-            # Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
+            # Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
             self.response_mutators.append(
                 token_response_mutator(
                     self.config,

--- a/supertokens_python/recipe/session/utils.py
+++ b/supertokens_python/recipe/session/utils.py
@@ -17,6 +17,8 @@ import json
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
+from typing_extensions import Literal
+
 from supertokens_python.exceptions import raise_general_exception
 from supertokens_python.framework import BaseResponse
 from supertokens_python.normalised_url_path import NormalisedURLPath
@@ -29,13 +31,10 @@ from supertokens_python.utils import (
     send_non_200_response,
     send_non_200_response_with_message,
 )
-from typing_extensions import Literal
 
 from ...types import MaybeAwaitable
-from .constants import SESSION_REFRESH, AUTH_MODE_HEADER_KEY
-from .cookie_and_header import (
-    clear_session_from_all_token_transfer_methods,
-)
+from .constants import AUTH_MODE_HEADER_KEY, SESSION_REFRESH
+from .cookie_and_header import clear_session_from_all_token_transfer_methods
 from .exceptions import ClaimValidationError
 from .with_jwt.constants import (
     ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY,
@@ -55,6 +54,8 @@ if TYPE_CHECKING:
     from .recipe import SessionRecipe
 
 from supertokens_python.logger import log_debug_message
+
+HUNDRED_YEARS_IN_MS = 3153600000000
 
 
 def normalise_session_scope(session_scope: str) -> str:


### PR DESCRIPTION
## Summary of change

Update access token cookie expiry logic and add comments.

Previously it was using seconds instead of ms. So instead of 100 years, it was being set to something like 47 years.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 