### PR TITLE
chore: Add dashboard init to all example apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Changed
+
+- Update all example apps to initialise dashboard recipe
+
 ## [0.12.3] - 2023-02-27
 - Adds APIs and logic to the dashboard recipe to enable email password based login
 ## [0.12.2] - 2023-02-23

--- a/examples/with-django/with-thirdpartyemailpassword/project/settings.py
+++ b/examples/with-django/with-thirdpartyemailpassword/project/settings.py
@@ -10,12 +10,13 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
-from pathlib import Path
 import os
-
-from dotenv import load_dotenv
+from pathlib import Path
 from typing import List
+
 from corsheaders.defaults import default_headers
+from dotenv import load_dotenv
+
 from supertokens_python import (
     InputAppInfo,
     SupertokensConfig,
@@ -23,9 +24,10 @@ from supertokens_python import (
     init,
 )
 from supertokens_python.recipe import (
+    dashboard,
+    emailverification,
     session,
     thirdpartyemailpassword,
-    emailverification,
 )
 from supertokens_python.recipe.thirdpartyemailpassword import (
     Apple,
@@ -66,6 +68,7 @@ init(
     mode="wsgi",
     recipe_list=[
         session.init(),
+        dashboard.init(),
         emailverification.init("REQUIRED"),
         thirdpartyemailpassword.init(
             providers=[

--- a/examples/with-fastapi/with-thirdpartyemailpassword/main.py
+++ b/examples/with-fastapi/with-thirdpartyemailpassword/main.py
@@ -6,6 +6,7 @@ from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse, PlainTextResponse
 from starlette.exceptions import ExceptionMiddleware
 from starlette.middleware.cors import CORSMiddleware
+
 from supertokens_python import (
     InputAppInfo,
     SupertokensConfig,
@@ -14,9 +15,10 @@ from supertokens_python import (
 )
 from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import (
+    dashboard,
+    emailverification,
     session,
     thirdpartyemailpassword,
-    emailverification,
 )
 from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.framework.fastapi import verify_session
@@ -56,6 +58,7 @@ init(
     framework="fastapi",
     recipe_list=[
         session.init(),
+        dashboard.init(),
         emailverification.init("REQUIRED"),
         thirdpartyemailpassword.init(
             providers=[

--- a/examples/with-flask/with-thirdpartyemailpassword/app.py
+++ b/examples/with-flask/with-thirdpartyemailpassword/app.py
@@ -12,6 +12,7 @@ from supertokens_python import (
 )
 from supertokens_python.framework.flask import Middleware
 from supertokens_python.recipe import (
+    dashboard,
     emailverification,
     session,
     thirdpartyemailpassword,
@@ -50,6 +51,7 @@ init(
     framework="flask",
     recipe_list=[
         session.init(),
+        dashboard.init(),
         emailverification.init("REQUIRED"),
         thirdpartyemailpassword.init(
             providers=[


### PR DESCRIPTION
## Summary of change

- Update example apps to also initialise the dashboard recipe

## Related issues

- 

## Test Plan

NA

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 
## Remaining TODOs for this PR

-   [ ] ...