### PR TITLE
fix: Fix failing django2x frontend integration tests

### DIFF
--- a/tests/frontendIntegration/django2x/polls/views.py
+++ b/tests/frontendIntegration/django2x/polls/views.py
@@ -545,7 +545,13 @@ def set_enable_jwt(request: HttpRequest):
 
 def feature_flags(request: HttpRequest):
     global last_set_enable_jwt
-    return JsonResponse({"sessionJwt": last_set_enable_jwt})
+    return JsonResponse(
+        {
+            "sessionJwt": last_set_enable_jwt,
+            "sessionClaims": is_version_gte(VERSION, "0.11.0"),
+            "v3AccessToken": is_version_gte(VERSION, "0.13.0"),
+        }
+    )
 
 
 def reinitialize(request: HttpRequest):


### PR DESCRIPTION
## Summary of change

Fix failing django2x frontend integration tests

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
 