### PR TITLE
feat: Make loading access token from the request overrideable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [unreleased]
+
+### Changes
+-   Made the access token string optional in the overrideable `get_session` function
+-   Moved checking if the access token is defined into the overrideable `get_session` function
+
 ## [0.13.0] - 2023-05-04
 ### Breaking changes
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.13.0",
+    version="0.13.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["2.21"]
-VERSION = "0.13.0"
+VERSION = "0.13.1"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/session/interfaces.py
+++ b/supertokens_python/recipe/session/interfaces.py
@@ -156,8 +156,8 @@ class RecipeInterface(ABC):  # pylint: disable=too-many-public-methods
     @abstractmethod
     async def get_session(
         self,
-        access_token: str,
-        anti_csrf_token: Optional[str],
+        access_token: Optional[str] = None,
+        anti_csrf_token: Optional[str] = None,
         anti_csrf_check: Optional[bool] = None,
         session_required: Optional[bool] = None,
         check_database: Optional[bool] = None,

--- a/supertokens_python/recipe/session/interfaces.py
+++ b/supertokens_python/recipe/session/interfaces.py
@@ -156,7 +156,7 @@ class RecipeInterface(ABC):  # pylint: disable=too-many-public-methods
     @abstractmethod
     async def get_session(
         self,
-        access_token: Optional[str] = None,
+        access_token: Optional[str],
         anti_csrf_token: Optional[str] = None,
         anti_csrf_check: Optional[bool] = None,
         session_required: Optional[bool] = None,

--- a/supertokens_python/recipe/session/recipe_implementation.py
+++ b/supertokens_python/recipe/session/recipe_implementation.py
@@ -171,8 +171,8 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
 
     async def get_session(
         self,
-        access_token: str,
-        anti_csrf_token: Optional[str],
+        access_token: Optional[str] = None,
+        anti_csrf_token: Optional[str] = None,
         anti_csrf_check: Optional[bool] = None,
         session_required: Optional[bool] = None,
         check_database: Optional[bool] = None,
@@ -193,6 +193,23 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
             )
 
         log_debug_message("getSession: Started")
+
+        if access_token is None:
+            if session_required is False:
+                log_debug_message(
+                    "getSession: returning None because access_token is undefined and session_required is False"
+                )
+                # there is no session that exists here, and the user wants session verification to be optional. So we return None
+                return None
+
+            log_debug_message(
+                "getSession: UNAUTHORISED because accessToken in request is undefined"
+            )
+            # we do not clear the session here because of a race condition mentioned in https://github.com/supertokens/supertokens-node/issues/17
+            raise UnauthorisedError(
+                "Session does not exist. Are you sending the session tokens in the request with the appropriate token transfer method?",
+                clear_tokens=False,
+            )
 
         access_token_obj: Optional[ParsedJWTInfo] = None
         try:

--- a/supertokens_python/recipe/session/recipe_implementation.py
+++ b/supertokens_python/recipe/session/recipe_implementation.py
@@ -171,7 +171,7 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
 
     async def get_session(
         self,
-        access_token: Optional[str] = None,
+        access_token: Optional[str],
         anti_csrf_token: Optional[str] = None,
         anti_csrf_check: Optional[bool] = None,
         session_required: Optional[bool] = None,


### PR DESCRIPTION
## Summary of change

Make loading access token from the request overrideable

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 