### PR TITLE
fix: Use requests instead of urllib for fetching jwks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.14.4] - 2023-06-12
+
+## Changes
+
+- Use request library instead of urllib to fetch JWKS keys ([#344](https://github.com/supertokens/supertokens-python/issues/344))
 
 ## [0.14.3] - 2023-06-7
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.14.3",
+    version="0.14.4",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["2.21"]
-VERSION = "0.14.3"
+VERSION = "0.14.4"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/session/jwks.py
+++ b/supertokens_python/recipe/session/jwks.py
@@ -6,7 +6,6 @@ from jwt import PyJWK, PyJWKSet
 from jwt.api_jwt import decode_complete as decode_token  # type: ignore
 
 from supertokens_python.utils import get_timestamp_ms
-from supertokens_python.logger import log_debug_message
 
 from .constants import JWKCacheMaxAgeInMs, JWKRequestCooldownInMs
 
@@ -43,7 +42,6 @@ class JWKClient:
 
     def reload(self):
         try:
-            log_debug_message("Fetching jwk set from the configured uri")
             with requests.get(self.uri, timeout=self.timeout_sec) as response:
                 response.raise_for_status()
                 self.jwk_set = PyJWKSet.from_dict(json.load(response))  # type: ignore


### PR DESCRIPTION
## Summary of change

Use requests instead of urllib for fetching jwks

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/344

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 