### PR TITLE
fix: Handle edge cases for verify_session decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes
+
+- Throw error when `verify_sesion` is used with a view that allows `OPTIONS` or `TRACE` requests
+- Allow `verify_session` decorator to be with `@app.before_request` in Flask without returning a response
+
 
 ## [0.14.3] - 2023-06-7
 

--- a/supertokens_python/recipe/session/api/implementation.py
+++ b/supertokens_python/recipe/session/api/implementation.py
@@ -73,6 +73,8 @@ class APIImplementation(APIInterface):
     ) -> Union[SessionContainer, None]:
         method = normalise_http_method(api_options.request.method())
         if method in ("options", "trace"):
+            if session_required:
+                raise Exception(f"verify_session cannot be used with {method} method")
             return None
         incoming_path = NormalisedURLPath(api_options.request.get_path())
         refresh_token_path = api_options.config.refresh_token_path

--- a/supertokens_python/recipe/session/framework/flask/__init__.py
+++ b/supertokens_python/recipe/session/framework/flask/__init__.py
@@ -61,8 +61,9 @@ def verify_session(
                 baseRequest.set_session_as_none()
             else:
                 baseRequest.set_session(session)
-            response = make_response(f(*args, **kwargs))
-            return response
+
+            response = f(*args, **kwargs)
+            return make_response(response) if response is not None else None
 
         return cast(_T, wrapped_function)
 


### PR DESCRIPTION
## Summary of change

Handle edge cases for `verify_session` decorator

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/346


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 