### PR TITLE
fix: Pass None to teardown function for min_version test wrapper

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -468,7 +468,7 @@ def get_core_api_version() -> str:
 
     api_version = asyncio.gather(get_api_version())
     core_version = loop.run_until_complete(api_version)[0]  # type: ignore # pylint: disable=unused-variable
-    teardown_function(_)
+    teardown_function(None)
     return core_version
 
 


### PR DESCRIPTION
## Summary of change

Pass None to teardown function for min_version test wrapper

This will fix the failing tests.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 