### PR TITLE
fix: Remove constraints on cryptography lib dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes and fixes
 
-- Removed constraints on `cryptograpy` dependency version
+- Remove constraints on `cryptograpy` dependency version
 
 ## [0.14.4] - 2023-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.14.5] - 2023-06-21
+
 ### Changes and fixes
 
 - Remove constraints on `cryptograpy` dependency version and let `pyjwt` library handle it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes and fixes
 
-- Remove constraints on `cryptograpy` dependency version
+- Remove constraints on `cryptograpy` dependency version and let `pyjwt` library handle it
 
 ## [0.14.4] - 2023-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes and fixes
+
+- Removed constraints on `cryptograpy` dependency version
+
 ## [0.14.4] - 2023-06-14
 
 ### Changes and fixes

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,8 @@ setup(
     ],
     keywords="",
     install_requires=[
-         # [crypto] ensures that it installs the `cryptography` library as well
-         # based on constraints specified in https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50
+        # [crypto] ensures that it installs the `cryptography` library as well
+        # based on constraints specified in https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50
         "PyJWT[crypto]>=2.6.0 ,<3.0.0",
         "httpx>=0.15.0 ,<0.24.0",
         "pycryptodome==3.10.*",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.14.4",
+    version="0.14.5",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,9 @@ setup(
     ],
     keywords="",
     install_requires=[
-        "PyJWT>=2.6.0 ,<3.0.0",
+         # [crypto] ensures that it installs the `cryptography` library as well
+         # based on constraints specified in https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50
+        "PyJWT[crypto]>=2.6.0 ,<3.0.0",
         "httpx>=0.15.0 ,<0.24.0",
         "pycryptodome==3.10.*",
         "tldextract==3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ setup(
         "asgiref>=3.4.1,<4",
         "typing_extensions>=4.1.1,<5.0.0",
         "Deprecated==1.2.13",
-        "cryptography>=35.0,<37.0",
         "phonenumbers==8.12.48",
         "twilio==7.9.1",
         "aiosmtplib==1.1.6",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["2.21"]
-VERSION = "0.14.4"
+VERSION = "0.14.5"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/thirdparty/providers/apple.py
+++ b/supertokens_python/recipe/thirdparty/providers/apple.py
@@ -17,6 +17,7 @@ from re import sub
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
 
+# cryptography lib is a dependency of PyJWT so no need to install/pin it
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from httpx import AsyncClient
 from jwt import decode, encode

--- a/supertokens_python/recipe/thirdparty/providers/apple.py
+++ b/supertokens_python/recipe/thirdparty/providers/apple.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 from re import sub
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
-
 from httpx import AsyncClient
 from jwt import decode, encode
+
+# You must have cryptography library installed for these imports to work:
 from jwt.algorithms import RSAAlgorithm
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
 from supertokens_python.recipe.thirdparty.api.implementation import (
     get_actual_client_id_from_development_client_id,
 )
@@ -35,8 +38,6 @@ from supertokens_python.supertokens import Supertokens
 
 if TYPE_CHECKING:
     from supertokens_python.framework.request import BaseRequest
-    # cryptography lib is a dependency of PyJWT so no need to install/pin it
-    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 
 class Apple(Provider):

--- a/supertokens_python/recipe/thirdparty/providers/apple.py
+++ b/supertokens_python/recipe/thirdparty/providers/apple.py
@@ -17,8 +17,6 @@ from re import sub
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
 
-# cryptography lib is a dependency of PyJWT so no need to install/pin it
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from httpx import AsyncClient
 from jwt import decode, encode
 from jwt.algorithms import RSAAlgorithm
@@ -37,6 +35,8 @@ from supertokens_python.supertokens import Supertokens
 
 if TYPE_CHECKING:
     from supertokens_python.framework.request import BaseRequest
+    # cryptography lib is a dependency of PyJWT so no need to install/pin it
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 
 class Apple(Provider):

--- a/tests/thirdparty/test_thirdparty.py
+++ b/tests/thirdparty/test_thirdparty.py
@@ -116,9 +116,8 @@ async def test_apple_provider_can_fetch_keys():
         apple = Apple(
             "client-id", "client-key-id", "client-private-key", "client-team-id"
         )
-        keys = (
-            await apple._fetch_apple_public_keys()  # pylint: disable=protected-access
-        )
+        # pylint: disable=protected-access
+        keys = await apple._fetch_apple_public_keys()  # type: ignore
 
         assert mocked_route.call_count == 1
         assert len(keys) == 3

--- a/tests/thirdparty/test_thirdparty.py
+++ b/tests/thirdparty/test_thirdparty.py
@@ -1,3 +1,6 @@
+import respx
+import httpx
+
 from pytest import fixture, mark
 from fastapi import FastAPI
 from supertokens_python.framework.fastapi import get_middleware
@@ -20,6 +23,8 @@ _ = start_st  # type:ignore
 
 
 pytestmark = mark.asyncio
+
+respx_mock = respx.MockRouter
 
 
 @fixture(scope="function")
@@ -64,3 +69,57 @@ async def test_thirdpary_parsing_works(fastapi_client: TestClient):
         res.content
         == b'<html><head><script>window.location.replace("http://supertokens.io/auth/callback/apple?state=afc596274293e1587315c&code=c7685e261f98e4b3b94e34b3a69ff9cf4.0.rvxt.eE8rO__6hGoqaX1B7ODPmA");</script></head></html>'
     )
+
+
+async def test_apple_provider_can_fetch_keys():
+    from supertokens_python.recipe.thirdparty.providers.apple import Apple
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
+    def api_side_effect(_: httpx.Request):
+        return httpx.Response(
+            200,
+            json={
+                "keys": [
+                    {
+                        "kty": "RSA",
+                        "kid": "W6WcOKB",
+                        "use": "sig",
+                        "alg": "RS256",
+                        "n": "2Zc5d0-zkZ5AKmtYTvxHc3vRc41YfbklflxG9SWsg5qXUxvfgpktGAcxXLFAd9Uglzow9ezvmTGce5d3DhAYKwHAEPT9hbaMDj7DfmEwuNO8UahfnBkBXsCoUaL3QITF5_DAPsZroTqs7tkQQZ7qPkQXCSu2aosgOJmaoKQgwcOdjD0D49ne2B_dkxBcNCcJT9pTSWJ8NfGycjWAQsvC8CGstH8oKwhC5raDcc2IGXMOQC7Qr75d6J5Q24CePHj_JD7zjbwYy9KNH8wyr829eO_G4OEUW50FAN6HKtvjhJIguMl_1BLZ93z2KJyxExiNTZBUBQbbgCNBfzTv7JrxMw",
+                        "e": "AQAB",
+                    },
+                    {
+                        "kty": "RSA",
+                        "kid": "fh6Bs8C",
+                        "use": "sig",
+                        "alg": "RS256",
+                        "n": "u704gotMSZc6CSSVNCZ1d0S9dZKwO2BVzfdTKYz8wSNm7R_KIufOQf3ru7Pph1FjW6gQ8zgvhnv4IebkGWsZJlodduTC7c0sRb5PZpEyM6PtO8FPHowaracJJsK1f6_rSLstLdWbSDXeSq7vBvDu3Q31RaoV_0YlEzQwPsbCvD45oVy5Vo5oBePUm4cqi6T3cZ-10gr9QJCVwvx7KiQsttp0kUkHM94PlxbG_HAWlEZjvAlxfEDc-_xZQwC6fVjfazs3j1b2DZWsGmBRdx1snO75nM7hpyRRQB4jVejW9TuZDtPtsNadXTr9I5NjxPdIYMORj9XKEh44Z73yfv0gtw",
+                        "e": "AQAB",
+                    },
+                    {
+                        "kty": "RSA",
+                        "kid": "YuyXoY",
+                        "use": "sig",
+                        "alg": "RS256",
+                        "n": "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+                        "e": "AQAB",
+                    },
+                ]
+            },
+        )
+
+    with respx_mock(assert_all_mocked=False) as mocker:
+        mocked_route = mocker.get("https://appleid.apple.com/auth/keys").mock(
+            side_effect=api_side_effect
+        )
+
+        apple = Apple(
+            "client-id", "client-key-id", "client-private-key", "client-team-id"
+        )
+        keys = (
+            await apple._fetch_apple_public_keys()  # pylint: disable=protected-access
+        )
+
+        assert mocked_route.call_count == 1
+        assert len(keys) == 3
+        assert isinstance(keys[0], RSAPublicKey)


### PR DESCRIPTION
## Summary of change

Remove constraints on cryptography lib dependency. It's already a [dependency](https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50) of `pyjwt` library. 

We were previously using it directly but looks like now it's just importing `RSAPublicKey` and even that is used just for  typing. So it should be safe to remove dependency constraints from our side.  

Added new test for Apple provider.

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/351

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 