### PR TITLE
fix: Relax version constraints on httpx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+
+## [0.14.6] - 2023-06-22
+
+### Changes and fixes
+
+- Relax constraints on `httpx` dependency version
+
 ## [0.14.5] - 2023-06-21
 
 ### Changes and fixes

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.14.5",
+    version="0.14.6",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",
@@ -101,8 +101,8 @@ setup(
     install_requires=[
         # [crypto] ensures that it installs the `cryptography` library as well
         # based on constraints specified in https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50
-        "PyJWT[crypto]>=2.6.0 ,<3.0.0",
-        "httpx>=0.15.0 ,<0.24.0",
+        "PyJWT[crypto]>=2.6.0,<3.0.0",
+        "httpx>=0.15.0,<0.25.0",
         "pycryptodome==3.10.*",
         "tldextract==3.1.0",
         "asgiref>=3.4.1,<4",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["2.21"]
-VERSION = "0.14.5"
+VERSION = "0.14.6"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"


### PR DESCRIPTION
## Summary of change

Relax version constraints on httpx dependency

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/358

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 