### PR TITLE
test: Verify session should return 401 if access token isn't sent and middleware isn't added

### DIFF
--- a/supertokens_python/recipe/session/framework/fastapi/__init__.py
+++ b/supertokens_python/recipe/session/framework/fastapi/__init__.py
@@ -64,7 +64,7 @@ def verify_session(
     return func
 
 
-async def st_exception_handler(request: Request, exc: SuperTokensError) -> JSONResponse:
+async def session_exception_handler(request: Request, exc: SuperTokensError) -> JSONResponse:
     """FastAPI exceptional handler for errors raised by Supertokens SDK when not using middleware
 
     Usage: `app.add_exception_handler(SuperTokensError, st_exception_handler)`

--- a/supertokens_python/recipe/session/framework/fastapi/__init__.py
+++ b/supertokens_python/recipe/session/framework/fastapi/__init__.py
@@ -64,7 +64,9 @@ def verify_session(
     return func
 
 
-async def session_exception_handler(request: Request, exc: SuperTokensError) -> JSONResponse:
+async def session_exception_handler(
+    request: Request, exc: SuperTokensError
+) -> JSONResponse:
     """FastAPI exceptional handler for errors raised by Supertokens SDK when not using middleware
 
     Usage: `app.add_exception_handler(SuperTokensError, st_exception_handler)`

--- a/tests/Django/test_django.py
+++ b/tests/Django/test_django.py
@@ -898,13 +898,13 @@ class SupertokensTest(TestCase):
 
         # Try with middleware
         request = self.factory.get("/verify")
-        response: HttpResponse = await middleware(verify_view)(request) # type: ignore
+        response: HttpResponse = await middleware(verify_view)(request)  # type: ignore
         assert response.status_code == 401
         assert json.loads(response.content) == {"message": "unauthorised"}
 
         # Try without middleware
         request = self.factory.get("/verify")
-        response: HttpResponse = await verify_view(request) # type: ignore
+        response: HttpResponse = await verify_view(request)  # type: ignore
         assert response.status_code == 401
         assert json.loads(response.content) == {"message": "unauthorised"}
 

--- a/tests/Django/test_django.py
+++ b/tests/Django/test_django.py
@@ -38,7 +38,14 @@ from supertokens_python.recipe.session.asyncio import (
 from supertokens_python.recipe.session.framework.django.asyncio import verify_session
 
 import pytest
-from tests.utils import clean_st, reset, setup_st, start_st, create_users, get_st_init_args
+from tests.utils import (
+    clean_st,
+    reset,
+    setup_st,
+    start_st,
+    create_users,
+    get_st_init_args,
+)
 from supertokens_python.recipe.dashboard import DashboardRecipe, InputOverrideConfig
 from supertokens_python.recipe.dashboard.interfaces import RecipeInterface
 from supertokens_python.framework import BaseRequest
@@ -115,7 +122,8 @@ async def optional_session(request: HttpRequest):
 @verify_session()
 async def verify_view(request: HttpRequest):
     session: SessionContainer = request.supertokens  # type: ignore
-    return JsonResponse({"handle": session.get_handle()}) # type: ignore
+    return JsonResponse({"handle": session.get_handle()})  # type: ignore
+
 
 class SupertokensTest(TestCase):
     def setUp(self):
@@ -880,21 +888,23 @@ class SupertokensTest(TestCase):
         data_json = json.loads(response.content)
         self.assertEqual(len(data_json["users"]), 0)
 
-    async def test_that_verify_session_return_401_if_access_token_is_not_sent_and_middleware_is_not_added(self):
-        args = get_st_init_args([session.init(get_token_transfer_method=lambda *_: "header")]) # type: ignore
+    async def test_that_verify_session_return_401_if_access_token_is_not_sent_and_middleware_is_not_added(
+        self,
+    ):
+        args = get_st_init_args([session.init(get_token_transfer_method=lambda *_: "header")])  # type: ignore
         args.update({"framework": "django"})
-        init(**args) # type: ignore
+        init(**args)  # type: ignore
         start_st()
 
         # Try with middleware
         request = self.factory.get("/verify")
-        response = await middleware(verify_view)(request)
+        response: HttpResponse = await middleware(verify_view)(request) # type: ignore
         assert response.status_code == 401
         assert json.loads(response.content) == {"message": "unauthorised"}
 
         # Try without middleware
         request = self.factory.get("/verify")
-        response = await verify_view(request)
+        response: HttpResponse = await verify_view(request) # type: ignore
         assert response.status_code == 401
         assert json.loads(response.content) == {"message": "unauthorised"}
 
@@ -905,13 +915,13 @@ class SupertokensTest(TestCase):
 
         # Now try with middleware:
         request = self.factory.get("/verify", {}, **headers)
-        response = await middleware(verify_view)(request)
+        response: JsonResponse = await middleware(verify_view)(request)  # type: ignore
         assert response.status_code == 200
         assert list(json.loads(response.content)) == ["handle"]
 
         # Now try without middleware:
         request = self.factory.get("/verify", **headers)
-        response = await verify_view(request)
+        response: JsonResponse = await verify_view(request)  # type: ignore
         assert response.status_code == 200
         assert list(json.loads(response.content)) == ["handle"]
 

--- a/tests/sessions/claims/test_verify_session.py
+++ b/tests/sessions/claims/test_verify_session.py
@@ -16,7 +16,7 @@ from supertokens_python.recipe.session.exceptions import (
 )
 from supertokens_python.recipe.session.framework.fastapi import (
     verify_session,
-    st_exception_handler,
+    session_exception_handler,
 )
 from supertokens_python.exceptions import SuperTokensError
 from supertokens_python.recipe.session.interfaces import (
@@ -550,7 +550,7 @@ async def client_without_middleware():
     async def _verify(s: Session = Depends(verify_session())):  # type: ignore
         return {"handle": s.get_handle()}
 
-    app.add_exception_handler(SuperTokensError, st_exception_handler)  # type: ignore
+    app.add_exception_handler(SuperTokensError, session_exception_handler)  # type: ignore
 
     return TestClient(app)
 

--- a/tests/sessions/claims/test_verify_session.py
+++ b/tests/sessions/claims/test_verify_session.py
@@ -221,9 +221,8 @@ async def fastapi_client():
     ):
         return {"handle": s.get_handle()}
 
-
     @app.post("/verify")
-    async def _verify(s: SessionContainer = Depends(verify_session())): # type: ignore
+    async def _verify(s: SessionContainer = Depends(verify_session())):  # type: ignore
         return {"handle": s.get_handle()}
 
     return TestClient(app)
@@ -551,8 +550,10 @@ async def client_without_middleware():
     return TestClient(app)
 
 
-async def test_that_verify_session_return_401_if_not_access_token_is_sent_and_middleware_is_not_added(client_without_middleware: TestClient, fastapi_client: TestClient):
-    init(**{ **st_init_common_args, "recipe_list": [session.init(get_token_transfer_method=lambda *_: "cookie")]}) # type: ignore
+async def test_that_verify_session_return_401_if_not_access_token_is_sent_and_middleware_is_not_added(
+    client_without_middleware: TestClient, fastapi_client: TestClient
+):
+    init(**{**st_init_common_args, "recipe_list": [session.init(get_token_transfer_method=lambda *_: "cookie")]})  # type: ignore
     start_st()
 
     res = fastapi_client.post("/verify")


### PR DESCRIPTION
## Summary of change

Verify session should return 401 if not access token is sent and middelware isn't added. This PR adds a test for that. 

Updated FastAPI and Flask. Django was already handling this. 


## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 
