### PR TITLE
fix: Anti csrf should happen only when access token is passed while session is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 
+## Fixes
+
+- Anti csrf check should happen only when access token is passed while session is optional
+
 ## [0.14.6] - 2023-06-22
 
 ### Changes and fixes

--- a/supertokens_python/recipe/session/session_request_functions.py
+++ b/supertokens_python/recipe/session/session_request_functions.py
@@ -153,6 +153,8 @@ async def get_session_from_request(
         do_anti_csrf_check = normalise_http_method(request.method()) != "get"
     if request_transfer_method == "header":
         do_anti_csrf_check = False
+    if request_access_token is None:
+        do_anti_csrf_check = False
 
     if do_anti_csrf_check and config.anti_csrf == "VIA_CUSTOM_HEADER":
         if config.anti_csrf == "VIA_CUSTOM_HEADER":

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -719,7 +719,7 @@ async def test_that_verify_session_doesnt_always_call_core():
     assert session3.refresh_token is not None
 
     assert (
-        AllowedProcessStates.CALLING_SERVICE_IN_VERIFYG
+        AllowedProcessStates.CALLING_SERVICE_IN_VERIFY
         not in ProcessState.get_instance().history
     )
 
@@ -741,11 +741,13 @@ async def test_that_verify_session_doesnt_always_call_core():
 async def test_anti_csrf_header_via_custom_header_check_happens_only_when_access_token_is_provided(
     driver_config_client: TestClient,
 ):
-    args = get_st_init_args([session.init(anti_csrf="VIA_CUSTOM_HEADER", get_token_transfer_method=lambda *_: "cookie")])  # type: ignore
+    args = get_st_init_args([session.init(anti_csrf="VIA_CUSTOM_HEADER", get_token_transfer_method=lambda *_: "cookie")]) # type: ignore
     init(**args)  # type: ignore
     start_st()
 
-    response = driver_config_client.post("/create")
+    response = driver_config_client.post(
+        "/create"
+    )
     assert response.status_code == 200
 
     # With access token:
@@ -755,8 +757,7 @@ async def test_anti_csrf_header_via_custom_header_check_happens_only_when_access
     assert response.json() == {"message": "try refresh token"}
 
     # with RID:
-    response = driver_config_client.post(
-        "/sessioninfo-optional",
+    response = driver_config_client.post("/sessioninfo-optional",
         headers={
             "rid": "session",
         },

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -741,13 +741,11 @@ async def test_that_verify_session_doesnt_always_call_core():
 async def test_anti_csrf_header_via_custom_header_check_happens_only_when_access_token_is_provided(
     driver_config_client: TestClient,
 ):
-    args = get_st_init_args([session.init(anti_csrf="VIA_CUSTOM_HEADER", get_token_transfer_method=lambda *_: "cookie")]) # type: ignore
+    args = get_st_init_args([session.init(anti_csrf="VIA_CUSTOM_HEADER", get_token_transfer_method=lambda *_: "cookie")])  # type: ignore
     init(**args)  # type: ignore
     start_st()
 
-    response = driver_config_client.post(
-        "/create"
-    )
+    response = driver_config_client.post("/create")
     assert response.status_code == 200
 
     # With access token:
@@ -757,7 +755,8 @@ async def test_anti_csrf_header_via_custom_header_check_happens_only_when_access
     assert response.json() == {"message": "try refresh token"}
 
     # with RID:
-    response = driver_config_client.post("/sessioninfo-optional",
+    response = driver_config_client.post(
+        "/sessioninfo-optional",
         headers={
             "rid": "session",
         },

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -260,8 +260,7 @@ async def driver_config_client():
     async def _session_info(s: Optional[SessionContainer] = Depends(verify_session(session_required=False))):  # type: ignore
         if s is not None:
             return JSONResponse({"session": s.get_handle(), "user_id": s.get_user_id()})
-        else:
-            return JSONResponse({"message": "no session"})
+        return JSONResponse({"message": "no session"})
 
     return TestClient(app)
 


### PR DESCRIPTION
## Summary of change

Anti csrf should happen only when access token is passed while session is optional

## Related issues

-   https://github.com/supertokens/supertokens-node/pull/610

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
