### PR TITLE
fix: Make tenant id compulsory in TypeGetAllowedDomainsForTenantId

### DIFF
--- a/supertokens_python/recipe/multitenancy/interfaces.py
+++ b/supertokens_python/recipe/multitenancy/interfaces.py
@@ -336,6 +336,6 @@ class APIInterface(ABC):
 
 
 TypeGetAllowedDomainsForTenantId = Callable[
-    [Optional[str], Dict[str, Any]],
+    [str, Dict[str, Any]],
     Awaitable[List[str]],
 ]


### PR DESCRIPTION
## Summary of change

Make tenant id compulsory in TypeGetAllowedDomainsForTenantId

## Related issues

-   https://github.com/supertokens/supertokens-node/pull/597

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 