### PR TITLE
fix: Make config optional

### DIFF
--- a/supertokens_python/recipe/multitenancy/asyncio/__init__.py
+++ b/supertokens_python/recipe/multitenancy/asyncio/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 async def create_or_update_tenant(
     tenant_id: Optional[str],
-    config: TenantConfig,
+    config: Optional[TenantConfig],
     user_context: Optional[Dict[str, Any]] = None,
 ) -> CreateOrUpdateTenantOkResult:
     if user_context is None:

--- a/supertokens_python/recipe/multitenancy/interfaces.py
+++ b/supertokens_python/recipe/multitenancy/interfaces.py
@@ -166,7 +166,7 @@ class RecipeInterface(ABC):
     async def create_or_update_tenant(
         self,
         tenant_id: Optional[str],
-        config: TenantConfig,
+        config: Optional[TenantConfig],
         user_context: Dict[str, Any],
     ) -> CreateOrUpdateTenantOkResult:
         pass

--- a/supertokens_python/recipe/multitenancy/recipe_implementation.py
+++ b/supertokens_python/recipe/multitenancy/recipe_implementation.py
@@ -132,14 +132,14 @@ class RecipeImplementation(RecipeInterface):
     async def create_or_update_tenant(
         self,
         tenant_id: Optional[str],
-        config: TenantConfig,
+        config: Optional[TenantConfig],
         user_context: Dict[str, Any],
     ) -> CreateOrUpdateTenantOkResult:
         response = await self.querier.send_put_request(
             NormalisedURLPath("/recipe/multitenancy/tenant"),
             {
                 "tenantId": tenant_id,
-                **config.to_json(),
+                **(config.to_json() if config is not None else {}),
             },
         )
         return CreateOrUpdateTenantOkResult(

--- a/supertokens_python/recipe/multitenancy/syncio/__init__.py
+++ b/supertokens_python/recipe/multitenancy/syncio/__init__.py
@@ -20,7 +20,7 @@ from ..interfaces import TenantConfig, ProviderConfig
 
 def create_or_update_tenant(
     tenant_id: Optional[str],
-    config: TenantConfig,
+    config: Optional[TenantConfig],
     user_context: Optional[Dict[str, Any]] = None,
 ):
     if user_context is None:


### PR DESCRIPTION
## Summary of change

Make config optional

## Related issues

-   https://github.com/supertokens/supertokens-python/pull/365

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [x] Make sure that `syncio` / `asyncio` functions are consistent.
 