### PR TITLE
fix: Set tenant_id as None by default in ep and userroles functions

### DIFF
--- a/supertokens_python/recipe/emailpassword/asyncio/__init__.py
+++ b/supertokens_python/recipe/emailpassword/asyncio/__init__.py
@@ -66,7 +66,7 @@ async def get_user_by_id(
 
 async def get_user_by_email(
     email: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ) -> Union[User, None]:
     if user_context is None:
@@ -78,7 +78,7 @@ async def get_user_by_email(
 
 async def create_reset_password_token(
     user_id: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     if user_context is None:
@@ -91,7 +91,7 @@ async def create_reset_password_token(
 async def reset_password_using_token(
     token: str,
     new_password: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     if user_context is None:
@@ -104,7 +104,7 @@ async def reset_password_using_token(
 async def sign_in(
     email: str,
     password: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     if user_context is None:
@@ -117,7 +117,7 @@ async def sign_in(
 async def sign_up(
     email: str,
     password: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     if user_context is None:

--- a/supertokens_python/recipe/emailpassword/syncio/__init__.py
+++ b/supertokens_python/recipe/emailpassword/syncio/__init__.py
@@ -51,7 +51,7 @@ def get_user_by_id(
 
 def get_user_by_email(
     email: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ) -> Union[None, User]:
     from supertokens_python.recipe.emailpassword.asyncio import get_user_by_email
@@ -61,7 +61,7 @@ def get_user_by_email(
 
 def create_reset_password_token(
     user_id: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     from supertokens_python.recipe.emailpassword.asyncio import (
@@ -74,7 +74,7 @@ def create_reset_password_token(
 def reset_password_using_token(
     token: str,
     new_password: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     from supertokens_python.recipe.emailpassword.asyncio import (
@@ -89,7 +89,7 @@ def reset_password_using_token(
 def sign_in(
     email: str,
     password: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ) -> Union[SignInOkResult, SignInWrongCredentialsError]:
     from supertokens_python.recipe.emailpassword.asyncio import sign_in
@@ -100,7 +100,7 @@ def sign_in(
 def sign_up(
     email: str,
     password: str,
-    tenant_id: Optional[str],
+    tenant_id: Optional[str] = None,
     user_context: Union[None, Dict[str, Any]] = None,
 ):
     from supertokens_python.recipe.emailpassword.asyncio import sign_up

--- a/supertokens_python/recipe/userroles/asyncio/__init__.py
+++ b/supertokens_python/recipe/userroles/asyncio/__init__.py
@@ -18,9 +18,9 @@ from supertokens_python.recipe.userroles.recipe import UserRolesRecipe
 
 
 async def add_role_to_user(
-    tenant_id: Optional[str],
     user_id: str,
     role: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> Union[AddRoleToUserOkResult, UnknownRoleError]:
     if user_context is None:
@@ -31,9 +31,9 @@ async def add_role_to_user(
 
 
 async def remove_user_role(
-    tenant_id: Optional[str],
     user_id: str,
     role: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> Union[RemoveUserRoleOkResult, UnknownRoleError]:
     if user_context is None:
@@ -44,8 +44,8 @@ async def remove_user_role(
 
 
 async def get_roles_for_user(
-    tenant_id: Optional[str],
     user_id: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> GetRolesForUserOkResult:
     if user_context is None:
@@ -58,8 +58,8 @@ async def get_roles_for_user(
 
 
 async def get_users_that_have_role(
-    tenant_id: Optional[str],
     role: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> Union[GetUsersThatHaveRoleOkResult, UnknownRoleError]:
     if user_context is None:

--- a/supertokens_python/recipe/userroles/syncio/__init__.py
+++ b/supertokens_python/recipe/userroles/syncio/__init__.py
@@ -31,45 +31,45 @@ from supertokens_python.recipe.userroles.interfaces import (
 
 
 def add_role_to_user(
-    tenant_id: Optional[str],
     user_id: str,
     role: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> Union[AddRoleToUserOkResult, UnknownRoleError]:
     from supertokens_python.recipe.userroles.asyncio import add_role_to_user
 
-    return sync(add_role_to_user(tenant_id, user_id, role, user_context))
+    return sync(add_role_to_user(user_id, role, tenant_id, user_context))
 
 
 def remove_user_role(
-    tenant_id: Optional[str],
     user_id: str,
     role: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> Union[RemoveUserRoleOkResult, UnknownRoleError]:
     from supertokens_python.recipe.userroles.asyncio import remove_user_role
 
-    return sync(remove_user_role(tenant_id, user_id, role, user_context))
+    return sync(remove_user_role(user_id, role, tenant_id, user_context))
 
 
 def get_roles_for_user(
-    tenant_id: Optional[str],
     user_id: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> GetRolesForUserOkResult:
     from supertokens_python.recipe.userroles.asyncio import get_roles_for_user
 
-    return sync(get_roles_for_user(tenant_id, user_id, user_context))
+    return sync(get_roles_for_user(user_id, tenant_id, user_context))
 
 
 def get_users_that_have_role(
-    tenant_id: Optional[str],
     role: str,
+    tenant_id: Optional[str] = None,
     user_context: Union[Dict[str, Any], None] = None,
 ) -> Union[GetUsersThatHaveRoleOkResult, UnknownRoleError]:
     from supertokens_python.recipe.userroles.asyncio import get_users_that_have_role
 
-    return sync(get_users_that_have_role(tenant_id, role, user_context))
+    return sync(get_users_that_have_role(role, tenant_id, user_context))
 
 
 def create_new_role_or_add_permissions(

--- a/tests/emailpassword/test_multitenancy.py
+++ b/tests/emailpassword/test_multitenancy.py
@@ -11,14 +11,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import setup
-
 from pytest import mark
 from supertokens_python.recipe import session, userroles, emailpassword, multitenancy
 from supertokens_python import init
 from supertokens_python.recipe.multitenancy.asyncio import (
     create_or_update_tenant,
-    associate_user_to_tenant,
 )
 from supertokens_python.recipe.emailpassword.asyncio import (
     sign_up,
@@ -28,14 +25,10 @@ from supertokens_python.recipe.emailpassword.asyncio import (
     create_reset_password_token,
     reset_password_using_token,
 )
+from supertokens_python.recipe.emailpassword.interfaces import SignUpOkResult, SignInOkResult, CreateResetPasswordOkResult
 from supertokens_python.recipe.multitenancy.interfaces import TenantConfig
-from supertokens_python.recipe.userroles.asyncio import (
-    create_new_role_or_add_permissions,
-    add_role_to_user,
-    get_roles_for_user,
-)
 
-from tests.sessions.claims.utils import get_st_init_args
+from tests.utils import get_st_init_args
 from tests.utils import setup_function, teardown_function, setup_multitenancy_feature
 
 
@@ -55,7 +48,7 @@ async def test_multitenancy_in_user_roles():
             multitenancy.init(),
         ]
     )
-    init(**args)
+    init(**args) # type: ignore
     setup_multitenancy_feature()
 
     await create_or_update_tenant("t1", TenantConfig(email_password_enabled=True))
@@ -65,6 +58,10 @@ async def test_multitenancy_in_user_roles():
     user1 = await sign_up("t1", "test@example.com", "password1")
     user2 = await sign_up("t2", "test@example.com", "password2")
     user3 = await sign_up("t3", "test@example.com", "password3")
+
+    assert isinstance(user1, SignUpOkResult)
+    assert isinstance(user2, SignUpOkResult)
+    assert isinstance(user3, SignUpOkResult)
 
     assert user1.user.user_id != user2.user.user_id
     assert user2.user.user_id != user3.user.user_id
@@ -78,6 +75,10 @@ async def test_multitenancy_in_user_roles():
     ep_user1 = await sign_in("t1", "test@example.com", "password1")
     ep_user2 = await sign_in("t2", "test@example.com", "password1")
     ep_user3 = await sign_in("t3", "test@example.com", "password1")
+
+    assert isinstance(ep_user1, SignInOkResult)
+    assert isinstance(ep_user2, SignInOkResult)
+    assert isinstance(ep_user3, SignInOkResult)
 
     assert ep_user1.user.user_id == user2.user.user_id == user3.user.user_id
 
@@ -104,6 +105,10 @@ async def test_multitenancy_in_user_roles():
     pless_reset_link2 = await create_reset_password_token("t2", user1.user.user_id)
     pless_reset_link3 = await create_reset_password_token("t3", user1.user.user_id)
 
+    assert isinstance(pless_reset_link1, CreateResetPasswordOkResult)
+    assert isinstance(pless_reset_link2, CreateResetPasswordOkResult)
+    assert isinstance(pless_reset_link3, CreateResetPasswordOkResult)
+
     assert pless_reset_link1.token is not None
     assert pless_reset_link2.token is not None
     assert pless_reset_link3.token is not None
@@ -117,6 +122,10 @@ async def test_multitenancy_in_user_roles():
     s_user1 = await sign_in("t1", "test@example.com", "newpassword1")
     s_user2 = await sign_in("t2", "test@example.com", "newpassword2")
     s_user3 = await sign_in("t3", "test@example.com", "newpassword3")
+
+    assert isinstance(s_user1, SignInOkResult)
+    assert isinstance(s_user2, SignInOkResult)
+    assert isinstance(s_user3, SignInOkResult)
 
     assert s_user1.user == user1.user
     assert s_user2.user == user2.user

--- a/tests/emailpassword/test_multitenancy.py
+++ b/tests/emailpassword/test_multitenancy.py
@@ -55,9 +55,9 @@ async def test_multitenancy_in_user_roles():
     await create_or_update_tenant("t2", TenantConfig(email_password_enabled=True))
     await create_or_update_tenant("t3", TenantConfig(email_password_enabled=True))
 
-    user1 = await sign_up("t1", "test@example.com", "password1")
-    user2 = await sign_up("t2", "test@example.com", "password2")
-    user3 = await sign_up("t3", "test@example.com", "password3")
+    user1 = await sign_up("test@example.com", "password1", "t1")
+    user2 = await sign_up("test@example.com", "password2", "t2")
+    user3 = await sign_up("test@example.com", "password3", "t3")
 
     assert isinstance(user1, SignUpOkResult)
     assert isinstance(user2, SignUpOkResult)
@@ -72,9 +72,9 @@ async def test_multitenancy_in_user_roles():
     assert user3.user.tenant_ids == ["t3"]
 
     # sign in
-    ep_user1 = await sign_in("t1", "test@example.com", "password1")
-    ep_user2 = await sign_in("t2", "test@example.com", "password1")
-    ep_user3 = await sign_in("t3", "test@example.com", "password1")
+    ep_user1 = await sign_in("test@example.com", "password1", "t1")
+    ep_user2 = await sign_in("test@example.com", "password1", "t2")
+    ep_user3 = await sign_in("test@example.com", "password1", "t3")
 
     assert isinstance(ep_user1, SignInOkResult)
     assert isinstance(ep_user2, SignInOkResult)
@@ -92,18 +92,18 @@ async def test_multitenancy_in_user_roles():
     assert g_user3 == user3.user
 
     # get user by email:
-    by_email_user1 = await get_user_by_email("t1", "test@example.com")
-    by_email_user2 = await get_user_by_email("t2", "test@example.com")
-    by_email_user3 = await get_user_by_email("t3", "test@example.com")
+    by_email_user1 = await get_user_by_email("test@example.com", "t1")
+    by_email_user2 = await get_user_by_email("test@example.com", "t2")
+    by_email_user3 = await get_user_by_email("test@example.com", "t3")
 
     assert by_email_user1 == user1.user
     assert by_email_user2 == user2.user
     assert by_email_user3 == user3.user
 
     # create password reset token:
-    pless_reset_link1 = await create_reset_password_token("t1", user1.user.user_id)
-    pless_reset_link2 = await create_reset_password_token("t2", user1.user.user_id)
-    pless_reset_link3 = await create_reset_password_token("t3", user1.user.user_id)
+    pless_reset_link1 = await create_reset_password_token(user1.user.user_id, "t1")
+    pless_reset_link2 = await create_reset_password_token(user1.user.user_id, "t2")
+    pless_reset_link3 = await create_reset_password_token(user1.user.user_id, "t3")
 
     assert isinstance(pless_reset_link1, CreateResetPasswordOkResult)
     assert isinstance(pless_reset_link2, CreateResetPasswordOkResult)
@@ -114,14 +114,14 @@ async def test_multitenancy_in_user_roles():
     assert pless_reset_link3.token is not None
 
     # reset password using token:
-    await reset_password_using_token("t1", pless_reset_link1.token, "newpassword1")
-    await reset_password_using_token("t2", pless_reset_link1.token, "newpassword2")
-    await reset_password_using_token("t3", pless_reset_link1.token, "newpassword3")
+    await reset_password_using_token(pless_reset_link1.token, "newpassword1", "t1")
+    await reset_password_using_token(pless_reset_link2.token, "newpassword2", "t2")
+    await reset_password_using_token(pless_reset_link3.token, "newpassword3", "t3")
 
     # new password should work:
-    s_user1 = await sign_in("t1", "test@example.com", "newpassword1")
-    s_user2 = await sign_in("t2", "test@example.com", "newpassword2")
-    s_user3 = await sign_in("t3", "test@example.com", "newpassword3")
+    s_user1 = await sign_in("test@example.com", "newpassword1", "t1")
+    s_user2 = await sign_in("test@example.com", "newpassword2", "t2")
+    s_user3 = await sign_in("test@example.com", "newpassword3", "t3")
 
     assert isinstance(s_user1, SignInOkResult)
     assert isinstance(s_user2, SignInOkResult)

--- a/tests/emailpassword/test_multitenancy.py
+++ b/tests/emailpassword/test_multitenancy.py
@@ -25,7 +25,11 @@ from supertokens_python.recipe.emailpassword.asyncio import (
     create_reset_password_token,
     reset_password_using_token,
 )
-from supertokens_python.recipe.emailpassword.interfaces import SignUpOkResult, SignInOkResult, CreateResetPasswordOkResult
+from supertokens_python.recipe.emailpassword.interfaces import (
+    SignUpOkResult,
+    SignInOkResult,
+    CreateResetPasswordOkResult,
+)
 from supertokens_python.recipe.multitenancy.interfaces import TenantConfig
 
 from tests.utils import get_st_init_args
@@ -48,7 +52,7 @@ async def test_multitenancy_in_user_roles():
             multitenancy.init(),
         ]
     )
-    init(**args) # type: ignore
+    init(**args)  # type: ignore
     setup_multitenancy_feature()
 
     await create_or_update_tenant("t1", TenantConfig(email_password_enabled=True))

--- a/tests/thirdparty/test_multitenancy.py
+++ b/tests/thirdparty/test_multitenancy.py
@@ -27,7 +27,7 @@ from supertokens_python.recipe.thirdparty.asyncio import (
 )
 from supertokens_python.recipe.multitenancy.interfaces import TenantConfig
 
-from tests.sessions.claims.utils import get_st_init_args
+from tests.utils import get_st_init_args
 from tests.utils import setup_function, teardown_function, setup_multitenancy_feature
 
 
@@ -40,7 +40,7 @@ pytestmark = mark.asyncio
 async def test_multitenancy_functions():
     # test that different roles can be assigned for the same user for each tenant
     args = get_st_init_args([session.init(), thirdparty.init(), multitenancy.init()])
-    init(**args)
+    init(**args) # type: ignore
     setup_multitenancy_feature()
 
     await create_or_update_tenant("t1", TenantConfig(third_party_enabled=True))

--- a/tests/thirdparty/test_multitenancy.py
+++ b/tests/thirdparty/test_multitenancy.py
@@ -40,7 +40,7 @@ pytestmark = mark.asyncio
 async def test_multitenancy_functions():
     # test that different roles can be assigned for the same user for each tenant
     args = get_st_init_args([session.init(), thirdparty.init(), multitenancy.init()])
-    init(**args) # type: ignore
+    init(**args)  # type: ignore
     setup_multitenancy_feature()
 
     await create_or_update_tenant("t1", TenantConfig(third_party_enabled=True))


### PR DESCRIPTION
## Summary of change

Set tenant_id as None by default in ep and userroles functions

## Related issues

No related issue. This is important to have a good DX for python devs, keep them consistent with other recipes (and modify fewer tests related to these recipes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [x] Make sure that `syncio` / `asyncio` functions are consistent.
 