### PR TITLE
fix: Remove error handlers from multitenancy recipe

### DIFF
--- a/supertokens_python/recipe/multitenancy/__init__.py
+++ b/supertokens_python/recipe/multitenancy/__init__.py
@@ -26,18 +26,16 @@ if TYPE_CHECKING:
 
     from ...recipe_module import RecipeModule
     from .interfaces import TypeGetAllowedDomainsForTenantId
-    from .utils import InputErrorHandlers, InputOverrideConfig
+    from .utils import InputOverrideConfig
 
 
 def init(
     get_allowed_domains_for_tenant_id: Union[
         TypeGetAllowedDomainsForTenantId, None
     ] = None,
-    error_handlers: Union[InputErrorHandlers, None] = None,
     override: Union[InputOverrideConfig, None] = None,
 ) -> Callable[[AppInfo], RecipeModule]:
     return recipe.MultitenancyRecipe.init(
         get_allowed_domains_for_tenant_id,
-        error_handlers,
         override,
     )

--- a/supertokens_python/recipe/multitenancy/exceptions.py
+++ b/supertokens_python/recipe/multitenancy/exceptions.py
@@ -16,9 +16,5 @@ from __future__ import annotations
 from supertokens_python.exceptions import SuperTokensError
 
 
-class TenantDoesNotExistError(SuperTokensError):
-    pass
-
-
-class RecipeDisabledForTenantError(SuperTokensError):
+class MultitenancyError(SuperTokensError):
     pass

--- a/supertokens_python/recipe/thirdparty/api/authorisation_url.py
+++ b/supertokens_python/recipe/thirdparty/api/authorisation_url.py
@@ -14,10 +14,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict
-from supertokens_python.recipe.multitenancy.constants import DEFAULT_TENANT_ID
-from supertokens_python.recipe.multitenancy.exceptions import (
-    RecipeDisabledForTenantError,
-)
 
 
 if TYPE_CHECKING:
@@ -56,11 +52,6 @@ async def handle_authorisation_url_api(
         tenant_id=tenant_id,
         user_context=user_context,
     )
-
-    if not provider_response.third_party_enabled:
-        raise RecipeDisabledForTenantError(
-            f"The third party recipe is disabled for {tenant_id if tenant_id != DEFAULT_TENANT_ID else 'default tenant'}"
-        )
 
     provider = provider_response.provider
     result = await api_implementation.authorisation_url_get(

--- a/supertokens_python/recipe/thirdparty/api/signinup.py
+++ b/supertokens_python/recipe/thirdparty/api/signinup.py
@@ -14,10 +14,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict
-from supertokens_python.recipe.multitenancy.constants import DEFAULT_TENANT_ID
-from supertokens_python.recipe.multitenancy.exceptions import (
-    RecipeDisabledForTenantError,
-)
 from supertokens_python.recipe.thirdparty.provider import RedirectUriInfo
 
 if TYPE_CHECKING:
@@ -67,11 +63,6 @@ async def handle_sign_in_up_api(
         tenant_id=tenant_id,
         user_context=user_context,
     )
-
-    if not provider_response.third_party_enabled:
-        raise RecipeDisabledForTenantError(
-            f"The third party recipe is disabled for {tenant_id if tenant_id is not None and tenant_id != DEFAULT_TENANT_ID else 'default tenant'}"
-        )
 
     provider = provider_response.provider
 

--- a/supertokens_python/recipe/thirdparty/interfaces.py
+++ b/supertokens_python/recipe/thirdparty/interfaces.py
@@ -53,9 +53,8 @@ class ManuallyCreateOrUpdateUserOkResult:
 
 
 class GetProviderOkResult:
-    def __init__(self, provider: Provider, third_party_enabled: bool):
+    def __init__(self, provider: Provider):
         self.provider = provider
-        self.third_party_enabled = third_party_enabled
 
 
 class RecipeInterface(ABC):

--- a/supertokens_python/recipe/thirdparty/recipe_implementation.py
+++ b/supertokens_python/recipe/thirdparty/recipe_implementation.py
@@ -200,5 +200,4 @@ class RecipeImplementation(RecipeInterface):
 
         return GetProviderOkResult(
             provider,
-            tenant_config.third_party.enabled,
         )


### PR DESCRIPTION
## Summary of change

Remove error handlers from multitenancy recipe

## Related issues

-   https://github.com/supertokens/supertokens-node/pull/632/

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
 
