### PR TITLE
chores: Bump version and mention pless signup function change in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [15.0.1] - 2023-09-22
+
+- Rename function `passwordlessSigninup` as `passwordless_signinup` in thirdpartypasswordless recipe
 
 ## [15.0.0] - 2023-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [15.0.1] - 2023-09-22
+## [0.15.1] - 2023-09-22
 
 - Rename function `passwordlessSigninup` as `passwordless_signinup` in thirdpartypasswordless recipe
 
-## [15.0.0] - 2023-09-16
+## [0.15.0] - 2023-09-16
 
 -   Fixes apple redirect
 -   Fixes an issue where the user management dashboard would incorrectly show an email as unverified even if it was verified

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.15.0",
+    version="0.15.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.15.0"
+VERSION = "0.15.1"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"


### PR DESCRIPTION

## Summary of change

Bump version and mention pless signup function change in CHANGELOG

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [x] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
