### PR TITLE
fix: Thirdparty providers bitbucket, boxy, and fb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.15.2] - 2023-09-23
+
+- Fixed bugs in thirdparty providers: Bitbucket, Boxy-SAML, and Facebook
+
 ## [0.15.1] - 2023-09-22
 - Fixes name of passwordless recipe function from `passwordlessSigninup` to `passwordless_signinup`
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.15.1",
+    version="0.15.2",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.15.1"
+VERSION = "0.15.2"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/thirdparty/providers/bitbucket.py
+++ b/supertokens_python/recipe/thirdparty/providers/bitbucket.py
@@ -77,7 +77,7 @@ class BitbucketImpl(GenericProvider):
 
         email = None
         is_verified = False
-        for email_info in user_info_from_email.values():
+        for email_info in user_info_from_email["values"]:
             if email_info["is_primary"]:
                 email = email_info["email"]
                 is_verified = email_info["is_confirmed"]

--- a/supertokens_python/recipe/thirdparty/providers/boxy_saml.py
+++ b/supertokens_python/recipe/thirdparty/providers/boxy_saml.py
@@ -56,13 +56,13 @@ def BoxySAML(input: ProviderInput) -> Provider:  # pylint: disable=redefined-bui
     if input.config.user_info_map is None:
         input.config.user_info_map = UserInfoMap(UserFields(), UserFields())
 
-    if input.config.user_info_map.from_id_token_payload is None:
-        input.config.user_info_map.from_id_token_payload = UserFields()
+    if input.config.user_info_map.from_user_info_api is None:
+        input.config.user_info_map.from_user_info_api = UserFields()
 
-    if input.config.user_info_map.from_id_token_payload.user_id is None:
-        input.config.user_info_map.from_id_token_payload.user_id = "id"
+    if input.config.user_info_map.from_user_info_api.user_id is None:
+        input.config.user_info_map.from_user_info_api.user_id = "id"
 
-    if input.config.user_info_map.from_id_token_payload.email is None:
-        input.config.user_info_map.from_id_token_payload.email = "email"
+    if input.config.user_info_map.from_user_info_api.email is None:
+        input.config.user_info_map.from_user_info_api.email = "email"
 
     return NewProvider(input, BoxySAMLImpl)

--- a/supertokens_python/recipe/thirdparty/providers/facebook.py
+++ b/supertokens_python/recipe/thirdparty/providers/facebook.py
@@ -37,7 +37,7 @@ class FacebookImpl(GenericProvider):
         config = await super().get_config_for_client_type(client_type, user_context)
 
         if config.scope is None:
-            config.scope = ["identify", "email"]
+            config.scope = ["email"]
 
         return config
 


### PR DESCRIPTION
## Summary of change

Fix thirdparty providers bitbucket, boxy, and FB

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

