### PR TITLE
fix: Failing CI tests for v0.12 patch release

### DIFF
--- a/supertokens_python/querier.py
+++ b/supertokens_python/querier.py
@@ -45,7 +45,7 @@ class Querier:
     __init_called = False
     __hosts: List[Host] = []
     __api_key: Union[None, str] = None
-    __api_version = None
+    api_version = None
     __last_tried_index: int = 0
     __hosts_alive_for_testing: Set[str] = set()
 
@@ -72,8 +72,8 @@ class Querier:
         return Querier.__hosts_alive_for_testing
 
     async def get_api_version(self):
-        if Querier.__api_version is not None:
-            return Querier.__api_version
+        if Querier.api_version is not None:
+            return Querier.api_version
 
         ProcessState.get_instance().add_state(
             AllowedProcessStates.CALLING_SERVICE_IN_GET_API_VERSION
@@ -99,8 +99,8 @@ class Querier:
                 "to find the right versions"
             )
 
-        Querier.__api_version = api_version
-        return Querier.__api_version
+        Querier.api_version = api_version
+        return Querier.api_version
 
     @staticmethod
     def get_instance(rid_to_core: Union[str, None] = None):
@@ -116,7 +116,7 @@ class Querier:
             Querier.__init_called = True
             Querier.__hosts = hosts
             Querier.__api_key = api_key
-            Querier.__api_version = None
+            Querier.api_version = None
             Querier.__last_tried_index = 0
             Querier.__hosts_alive_for_testing = set()
 

--- a/tests/frontendIntegration/django2x/polls/urls.py
+++ b/tests/frontendIntegration/django2x/polls/urls.py
@@ -6,6 +6,7 @@ from . import views
 urlpatterns = [  # type: ignore
     path("index.html", views.send_file, name="index.html"),  # type: ignore
     path("login", views.login, name="login"),  # type: ignore
+    path("login-2.18", views.login_2_18, name="login"),  # type: ignore
     path("beforeeach", views.before_each, name="beforeeach"),  # type: ignore
     path("testUserConfig", views.test_config, name="testUserConfig"),  # type: ignore
     path(

--- a/tests/frontendIntegration/django2x/polls/views.py
+++ b/tests/frontendIntegration/django2x/polls/views.py
@@ -336,6 +336,18 @@ def login(request: HttpRequest):
         return send_options_api_response()
 
 
+def login_2_18(request: HttpRequest):
+    if request.method == "POST":
+        body = json.loads(request.body)
+        user_id = body["userId"]
+        payload = body["payload"]
+
+        session_ = create_new_session(request, user_id, payload)
+        return HttpResponse(session_.get_user_id())
+    else:
+        return send_options_api_response()
+
+
 def before_each(request: HttpRequest):
     if request.method == "POST":
         Test.reset()

--- a/tests/frontendIntegration/django3x/polls/urls.py
+++ b/tests/frontendIntegration/django3x/polls/urls.py
@@ -6,6 +6,7 @@ from . import views
 urlpatterns = [  # type: ignore
     path("index.html", views.send_file, name="index.html"),  # type: ignore
     path("login", views.login, name="login"),  # type: ignore
+    path("login-2.18", views.login, name="login"),  # type: ignore
     path("beforeeach", views.before_each, name="beforeeach"),  # type: ignore
     path("testUserConfig", views.test_config, name="testUserConfig"),  # type: ignore
     path(

--- a/tests/frontendIntegration/django3x/polls/views.py
+++ b/tests/frontendIntegration/django3x/polls/views.py
@@ -343,6 +343,18 @@ async def login(request: HttpRequest):
         return send_options_api_response()
 
 
+async def login_2_18(request: HttpRequest):
+    if request.method == "POST":
+        body = json.loads(request.body)
+        user_id = body["userId"]
+        payload = body["payload"]
+
+        session_ = await create_new_session(request, user_id, payload)
+        return HttpResponse(session_.get_user_id())
+    else:
+        return send_options_api_response()
+
+
 async def before_each(request: HttpRequest):
     if request.method == "POST":
         Test.reset()

--- a/tests/frontendIntegration/fastapi-server/app.py
+++ b/tests/frontendIntegration/fastapi-server/app.py
@@ -218,6 +218,13 @@ async def login(request: Request):
     _session = await create_new_session(request, user_id)
     return PlainTextResponse(content=_session.get_user_id())
 
+@app.post("/login-2.18")
+async def login_2_18(request: Request):
+    body = await request.json()
+    user_id = body["userId"]
+    payload = body["payload"]
+    _session = await create_new_session(request, user_id, payload)
+    return PlainTextResponse(content=_session.get_user_id())
 
 @app.options("/beforeeach")
 def before_each_options():

--- a/tests/frontendIntegration/fastapi-server/app.py
+++ b/tests/frontendIntegration/fastapi-server/app.py
@@ -218,6 +218,7 @@ async def login(request: Request):
     _session = await create_new_session(request, user_id)
     return PlainTextResponse(content=_session.get_user_id())
 
+
 @app.post("/login-2.18")
 async def login_2_18(request: Request):
     body = await request.json()
@@ -225,6 +226,7 @@ async def login_2_18(request: Request):
     payload = body["payload"]
     _session = await create_new_session(request, user_id, payload)
     return PlainTextResponse(content=_session.get_user_id())
+
 
 @app.options("/beforeeach")
 def before_each_options():

--- a/tests/frontendIntegration/flask-server/app.py
+++ b/tests/frontendIntegration/flask-server/app.py
@@ -245,6 +245,15 @@ def login():
     return _session.get_user_id()
 
 
+@app.route("/login-2.18", methods=["POST"])  # type: ignore
+def login_2_18():
+    body: Dict[str, Any] = request.get_json()  # type: ignore
+    user_id = body["userId"]
+    payload = body["payload"]
+    _session = create_new_session(request, user_id, payload)
+    return _session.get_user_id()
+
+
 @app.route("/beforeeach", methods=["OPTIONS"])  # type: ignore
 def before_each_options():
     return send_options_api_response()


### PR DESCRIPTION
## Summary of change

Fix failing CI tests for v0.12 patch release


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
