### PR TITLE
fix: JWT lifetime setting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
-## [0.12.10] - 2023-09-28
+## [0.12.10] - 2023-09-01
 
 - Add logic to retry network calls if the core returns status 429
+- Fixes session recipe with jwt where the lifetime of the jwt is set to 1 in case it is `< 1`
 
 ## [0.12.9] - 2023-04-28
 

--- a/supertokens_python/recipe/session/with_jwt/recipe_implementation.py
+++ b/supertokens_python/recipe/session/with_jwt/recipe_implementation.py
@@ -160,6 +160,7 @@ def get_recipe_implementation_with_jwt(
             raise Exception("Error reading JWT from session")
 
         jwt_expiry = decoded_payload.get("exp", 0) - current_time_in_seconds
+        # pylint: disable=consider-using-max-builtin
         if jwt_expiry < 1:
             # it can come here if someone calls this function well after
             # the access token and the jwt payload have expired. In this case,
@@ -167,6 +168,7 @@ def get_recipe_implementation_with_jwt(
             # not be alive for too long (since it's expired already). So we set it to
             # 1 second lifetime.
             jwt_expiry = 1
+        # pylint: enable=consider-using-max-builtin
 
         new_access_token_payload = await add_jwt_to_access_token_payload(
             access_token_payload=new_access_token_payload,

--- a/supertokens_python/recipe/session/with_jwt/session_class.py
+++ b/supertokens_python/recipe/session/with_jwt/session_class.py
@@ -70,16 +70,16 @@ def get_session_with_jwt(
         if decoded_payload is None or decoded_payload.get("exp") is None:
             raise Exception("Error reading JWT from session")
 
-        jwt_expiry = 1
-        if "exp" in decoded_payload:
-            exp = decoded_payload["exp"]
-            if exp > current_time_in_seconds:
-                # it can come here if someone calls this function well after
-                # the access token and the jwt payload have expired. In this case,
-                # we still want the jwt payload to update, but the resulting JWT should
-                # not be alive for too long (since it's expired already). So we set it to
-                # 1 second lifetime.
-                jwt_expiry = exp - current_time_in_seconds
+        jwt_expiry = decoded_payload.get("exp", 0) - current_time_in_seconds
+        # pylint: disable=consider-using-max-builtin
+        if jwt_expiry < 1:
+            # it can come here if someone calls this function well after
+            # the access token and the jwt payload have expired. In this case,
+            # we still want the jwt payload to update, but the resulting JWT should
+            # not be alive for too long (since it's expired already). So we set it to
+            # 1 second lifetime.
+            jwt_expiry = 1
+        # pylint: enable=consider-using-max-builtin
 
         new_access_token_payload = await add_jwt_to_access_token_payload(
             access_token_payload=new_access_token_payload,


### PR DESCRIPTION
## Summary of change

Fixes session recipe with jwt where the lifetime of the jwt is set to 1 in case it is < 1

## Related issues

-   https://github.com/supertokens/supertokens-node/pull/681/

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
