### PR TITLE
fix: Failing django2x website tests

### DIFF
--- a/tests/frontendIntegration/django2x/polls/views.py
+++ b/tests/frontendIntegration/django2x/polls/views.py
@@ -373,14 +373,11 @@ def login_2_18(request: HttpRequest):
             {"uid": user_id, "ate": get_timestamp_ms() + 3600000, "up": payload}
         )
 
-        return JsonResponse(
-            {},
-            headers={
-                "st-access-token": legacy_access_token,
-                "st-refresh-token": legacy_refresh_token,
-                "front-token": b64encode(front_token.encode()).decode(),
-            },
-        )
+        res = JsonResponse({})
+        res["st-access-token"] = legacy_access_token
+        res["st-refresh-token"] = legacy_refresh_token
+        res["front-token"] = b64encode(front_token.encode()).decode()
+        return res
     else:
         return send_options_api_response()
 


### PR DESCRIPTION
## Summary of change

Fix failing django2x website tests

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
