### PR TITLE
fix: ignore protected props in create_new_session functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+
+## [0.16.0] - 2023-09-13
+
+
 ### Added
 
 -   The Dashboard recipe now accepts a new `admins` property which can be used to give Dashboard Users write privileges for the user dashboard.
@@ -15,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 -   Dashboard APIs now return a status code `403` for all non-GET requests if the currently logged in Dashboard User is not listed in the `admins` array
+- Now ignoring protected props in the payload in `create_new_session` and `create_new_session_without_request_response`
 
 ## [0.15.3] - 2023-09-24
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.15.3",
+    version="0.16.0",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.15.3"
+VERSION = "0.16.0"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/session/asyncio/__init__.py
+++ b/supertokens_python/recipe/session/asyncio/__init__.py
@@ -41,6 +41,7 @@ from ..session_request_functions import (
     get_session_from_request,
     refresh_session_in_request,
 )
+from ..constants import protected_props
 from ..utils import get_required_claim_validators
 
 from supertokens_python.recipe.multitenancy.constants import DEFAULT_TENANT_ID
@@ -105,6 +106,10 @@ async def create_new_session_without_request_response(
     )
 
     final_access_token_payload = {**access_token_payload, "iss": issuer}
+
+    for prop in protected_props:
+        if prop in final_access_token_payload:
+            del final_access_token_payload[prop]
 
     for claim in claims_added_by_other_recipes:
         update = await claim.build(user_id, tenant_id, user_context)

--- a/supertokens_python/recipe/session/constants.py
+++ b/supertokens_python/recipe/session/constants.py
@@ -42,5 +42,6 @@ protected_props = [
     "parentRefreshTokenHash1",
     "refreshTokenHash1",
     "antiCsrfToken",
+    "rsub",
     "tId",
 ]

--- a/supertokens_python/recipe/session/recipe_implementation.py
+++ b/supertokens_python/recipe/session/recipe_implementation.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from supertokens_python import AppInfo
 
 from .interfaces import SessionContainer
+from .constants import protected_props
 from supertokens_python.querier import Querier
 from supertokens_python.recipe.multitenancy.constants import DEFAULT_TENANT_ID
 
@@ -378,8 +379,13 @@ class RecipeImplementation(RecipeInterface):  # pylint: disable=too-many-public-
         if session_info is None:
             return False
 
+        new_access_token_payload = session_info.custom_claims_in_access_token_payload
+        for k in protected_props:
+            if k in new_access_token_payload:
+                del new_access_token_payload[k]
+
         new_access_token_payload = {
-            **session_info.custom_claims_in_access_token_payload,
+            **new_access_token_payload,
             **access_token_payload_update,
         }
         for k in access_token_payload_update.keys():

--- a/supertokens_python/recipe/session/session_request_functions.py
+++ b/supertokens_python/recipe/session/session_request_functions.py
@@ -60,6 +60,7 @@ from supertokens_python.utils import (
     set_request_in_user_context_if_not_defined,
 )
 from supertokens_python.supertokens import Supertokens
+from .constants import protected_props
 
 if TYPE_CHECKING:
     from supertokens_python.recipe.session.recipe import SessionRecipe
@@ -239,6 +240,10 @@ async def create_new_session_in_request(
     )
 
     final_access_token_payload = {**access_token_payload, "iss": issuer}
+
+    for prop in protected_props:
+        if prop in final_access_token_payload:
+            del final_access_token_payload[prop]
 
     for claim in claims_added_by_other_recipes:
         update = await claim.build(user_id, tenant_id, user_context)

--- a/tests/sessions/test_access_token_version.py
+++ b/tests/sessions/test_access_token_version.py
@@ -203,27 +203,25 @@ async def test_should_validate_v3_tokens_with_check_database_enabled(app: TestCl
     }
 
 
-async def test_ignore_protected_props_in_create_session(app: TestClient):
-    init(**get_st_init_args([session.init()]))  # type:ignore
+async def test_ignore_protected_props_in_create_session():
+    init(**get_st_init_args([session.init()]))
     start_st()
 
-    create_session_res = app.post("/create", data={"sub": "asdf"})
-
-    assert create_session_res.status_code == 200
-
-    info = extract_info(create_session_res)
-    assert info["accessTokenFromAny"] is not None
-    assert info["refreshTokenFromAny"] is not None
-    assert info["frontToken"] is not None
-
-    parsed_token = parse_jwt_without_signature_verification(info["accessTokenFromAny"])
-    assert parsed_token.payload["sub"] != "asdf"
-
     s = await create_new_session_without_request_response(
-        "public", "user-id", {"sub": "asdf"}
+        "public",
+        "user1",
+        {"foo": "bar"},
     )
     payload = parse_jwt_without_signature_verification(s.access_token).payload
-    assert payload["sub"] != "asdf"
+    assert payload["foo"] == "bar"
+    assert payload["sub"] == "user1"
+
+    s2 = await create_new_session_without_request_response(
+        "public", "user2", s.get_access_token_payload()
+    )
+    payload = parse_jwt_without_signature_verification(s2.access_token).payload
+    assert payload["foo"] == "bar"
+    assert payload["sub"] == "user2"
 
 
 async def test_validation_logic_with_keys_that_can_use_json_nulls_values_in_claims():

--- a/tests/sessions/test_access_token_version.py
+++ b/tests/sessions/test_access_token_version.py
@@ -203,6 +203,29 @@ async def test_should_validate_v3_tokens_with_check_database_enabled(app: TestCl
     }
 
 
+async def test_ignore_protected_props_in_create_session(app: TestClient):
+    init(**get_st_init_args([session.init()]))  # type:ignore
+    start_st()
+
+    create_session_res = app.post("/create", data={"sub": "asdf"})
+
+    assert create_session_res.status_code == 200
+
+    info = extract_info(create_session_res)
+    assert info["accessTokenFromAny"] is not None
+    assert info["refreshTokenFromAny"] is not None
+    assert info["frontToken"] is not None
+
+    parsed_token = parse_jwt_without_signature_verification(info["accessTokenFromAny"])
+    assert parsed_token.payload["sub"] != "asdf"
+
+    s = await create_new_session_without_request_response(
+        "public", "user-id", {"sub": "asdf"}
+    )
+    payload = parse_jwt_without_signature_verification(s.access_token).payload
+    assert payload["sub"] != "asdf"
+
+
 async def test_validation_logic_with_keys_that_can_use_json_nulls_values_in_claims():
     """We want to make sure that for access token claims that can be null, the SDK does not fail access token validation if the
     core does not send them as part of the payload. For this we verify that validation passes when the keys are None, empty,


### PR DESCRIPTION
## Summary of change

Ignore protected props in `create_new_session` functions

## Related
- https://github.com/supertokens/supertokens-node/pull/690


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
