### PR TITLE
resolves #445

### DIFF
--- a/supertokens_python/recipe/thirdparty/providers/custom.py
+++ b/supertokens_python/recipe/thirdparty/providers/custom.py
@@ -162,7 +162,7 @@ async def verify_id_token_from_jwks_endpoint_and_get_payload(
     err = Exception("id token verification failed")
     for key in public_keys:
         try:
-            return decode(jwt=id_token, key=key, audience=[audience], algorithms=["RS256"])  # type: ignore
+            return decode(jwt=id_token, key=key, audience=[audience], algorithms=["RS256"], leeway=2)  # type: ignore
         except Exception as e:
             err = e
     raise err


### PR DESCRIPTION
## Summary of change

There is an [issue](https://github.com/supertokens/supertokens-python/issues/445) with `Google Social Login` in the sample projects with `Python` backend frameworks. Adding a `leeway` of 2 seconds when decoding the JWT resolves the problem, however, the value of 2 is arbitrary (it was chosen based on experimentation).

## Related issues

-  https://github.com/supertokens/supertokens-python/issues/445

## Remaining TODOs for this PR

-   [ ] Make sure that this change does not introduce any vulnerabilities
-   [ ] Fine-tune the `leeway` value if appropriate
