### PR TITLE
fix: Handle AWS public urls separately when extracting TLDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.1] - 2023-09-19
+- Handle AWS Public URLs (ending with `.amazonaws.com`) separately while extracting TLDs for SameSite attribute.
+
 
 ## [0.16.0] - 2023-09-13
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.16.0",
+    version="0.16.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.16.0"
+VERSION = "0.16.1"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/utils.py
+++ b/supertokens_python/utils.py
@@ -299,8 +299,13 @@ def get_top_level_domain_for_same_site_resolution(url: str) -> str:
 
     if hostname.startswith("localhost") or is_an_ip_address(hostname):
         return "localhost"
+
     parsed_url: Any = extract(hostname, include_psl_private_domains=True)
     if parsed_url.domain == "":  # type: ignore
+        # We need to do this because of https://github.com/supertokens/supertokens-python/issues/394
+        if hostname.endswith(".amazonaws.com") and parsed_url.suffix == hostname:
+            return hostname
+
         raise Exception(
             "Please make sure that the apiDomain and websiteDomain have correct values"
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -736,3 +736,67 @@ async def test_samesite_invalid_config():
             )
         else:
             assert False, "Exception not raised"
+
+
+@mark.asyncio
+async def test_cookie_samesite_with_ec2_public_url():
+    start_st()
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="https://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com:3001",
+            website_domain="https://blog.supertokens.com",
+            api_base_path="/",
+        ),
+        framework="fastapi",
+        recipe_list=[
+            session.init(get_token_transfer_method=lambda _, __, ___: "cookie")
+        ],
+    )
+
+    # domain name isn't provided so browser decides to use the same host
+    # which will be ec2-xx-yyy-zzz-0.compute-1.amazonaws.com
+    assert SessionRecipe.get_instance().config.cookie_domain is None
+    assert SessionRecipe.get_instance().config.cookie_same_site == "none"
+    assert SessionRecipe.get_instance().config.cookie_secure is True
+
+    reset()
+
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="http://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com:3001",
+            website_domain="http://ec2-aa-bbb-ccc-0.compute-1.amazonaws.com:3000",
+            api_base_path="/",
+        ),
+        framework="fastapi",
+        recipe_list=[
+            session.init(get_token_transfer_method=lambda _, __, ___: "cookie")
+        ],
+    )
+
+    assert SessionRecipe.get_instance().config.cookie_domain is None
+    assert SessionRecipe.get_instance().config.cookie_same_site == "none"
+    assert SessionRecipe.get_instance().config.cookie_secure is False
+
+    reset()
+
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="http://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com:3001",
+            website_domain="http://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com:3000",
+            api_base_path="/",
+        ),
+        framework="fastapi",
+        recipe_list=[
+            session.init(get_token_transfer_method=lambda _, __, ___: "cookie")
+        ],
+    )
+
+    assert SessionRecipe.get_instance().config.cookie_domain is None
+    assert SessionRecipe.get_instance().config.cookie_same_site == "lax"
+    assert SessionRecipe.get_instance().config.cookie_secure is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,11 @@ from typing import Union, List, Any, Dict
 import pytest
 import threading
 
-from supertokens_python.utils import humanize_time, is_version_gte
+from supertokens_python.utils import (
+    humanize_time,
+    is_version_gte,
+    get_top_level_domain_for_same_site_resolution,
+)
 from supertokens_python.utils import RWMutex
 
 from tests.utils import is_subset
@@ -171,3 +175,25 @@ def test_rw_mutex_writes():
     expected_balance -= 10 * 5  # 10 threads withdrawing 5 each
     actual_balance, _ = account.get_stats()
     assert actual_balance == expected_balance, "Incorrect account balance"
+
+
+@pytest.mark.parametrize(
+    "url,res",
+    [
+        ("http://localhost:3001", "localhost"),
+        (
+            "https://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com",
+            "ec2-xx-yyy-zzz-0.compute-1.amazonaws.com",
+        ),
+        (
+            "https://foo.vercel.com",
+            "vercel.com",
+        ),
+        (
+            "https://blog.supertokens.com",
+            "supertokens.com",
+        ),
+    ],
+)
+def test_tld_for_same_site(url: str, res: str):
+    assert get_top_level_domain_for_same_site_resolution(url) == res


### PR DESCRIPTION
## Summary of change

Handle AWS public urls separately when extracting TLDs

## Related issues

-   https://github.com/supertokens/supertokens-python/issues/394

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
