### PR TITLE
chores: Mention SDK and core versions compatible after 0.15 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             }
         }
         ```
+### SDK and core compatibility
+
+- Compatible with Core>=6.0.0 (CDI 4.0)
+- Compatible with frontend SDKs:
+    - supertokens-auth-react@0.34.0
+    - supertokens-web-js@0.7.0
+    - supertokens-website@17.0.2
+
 
 ## [0.14.8] - 2023-07-07
 ## Fixes


### PR DESCRIPTION
## Summary of change

Mention SDK and core versions compatible after migrating to `v0.15` 

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
