### PR TITLE
Relax `pyJWT` dependency constraint to `2.5.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.16.5] - 2023-10-23
 
 - Relaxed constraint on `pyJWT` dependency.
-  - This is done because some users face `InvalidSignatureError` when decoding the access token with the latest `pyJWT` version.
+  - This is done because some users face `InvalidSignatureError` when decoding the id token with the latest `pyJWT` version.
 
 ## [0.16.4] - 2023-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.5] - 2023-10-23
+
+- Relaxed constraint on `pyJWT` dependency.
+  - This is done because some users face `InvalidSignatureError` when decoding the access token with the latest `pyJWT` version.
+
 ## [0.16.4] - 2023-10-05
 
 - Add `validate_access_token` function to providers

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     install_requires=[
         # [crypto] ensures that it installs the `cryptography` library as well
         # based on constraints specified in https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50
-        "PyJWT[crypto]>=2.6.0,<3.0.0",
+        "PyJWT[crypto]>=2.5.0,<3.0.0",
         "httpx>=0.15.0,<0.25.0",
         "pycryptodome==3.10.*",
         "tldextract==3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.16.4",
+    version="0.16.5",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.16.4"
+VERSION = "0.16.5"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"


### PR DESCRIPTION
## Summary of change

- Relaxed constraint on `pyJWT` dependency.
  - This is done because some users face `InvalidSignatureError` when decoding the access token with the latest `pyJWT` version.

## Related issues

-   #445 

## Test Plan

Difficult to reproduce the issue, but all the existing tests work, so the change is safe to make.

## Documentation changes


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

