### PR TITLE
fix: server error when `redirect_uri_info` is not passed in the sign_in_up API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.6] - 2023-10-24
+
+- Fixed server error in `sign_in_up` API
+    - There was a bug in case where the API was called with just oAuth tokens without passing the `redirect_uri_info`.
+
 ## [0.16.5] - 2023-10-23
 
 - Relaxed constraint on `pyJWT` dependency.

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.16.5",
+    version="0.16.6",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.16.5"
+VERSION = "0.16.6"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/tests/thirdparty/test_thirdparty.py
+++ b/tests/thirdparty/test_thirdparty.py
@@ -49,7 +49,7 @@ async def fastapi_client():
     app = FastAPI()
     app.add_middleware(get_middleware())
 
-    return TestClient(app, raise_server_exceptions=True)
+    return TestClient(app, raise_server_exceptions=False)
 
 
 async def test_thirdpary_parsing_works(fastapi_client: TestClient):


### PR DESCRIPTION
## Summary of change

Fixed server error when the sign in up API was called using oAuthTokens without passing the `redirect_uri_info`.

## Related issues



## Test Plan

Added unit test

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

