### PR TITLE
feat: added debug flag in the SuperTokenConfig in the init() for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.7] - 2023-11-2
+
+- Added `debug` flag in `init()`. If set to `True`, debug logs will be printed.
+
 ## [0.16.6] - 2023-10-24
 
 - Fixed server error in `sign_in_up` API

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.16.6",
+    version="0.16.7",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/__init__.py
+++ b/supertokens_python/__init__.py
@@ -34,14 +34,10 @@ def init(
     recipe_list: List[Callable[[supertokens.AppInfo], RecipeModule]],
     mode: Optional[Literal["asgi", "wsgi"]] = None,
     telemetry: Optional[bool] = None,
+    debug: Optional[bool] = None,
 ):
     return Supertokens.init(
-        app_info,
-        framework,
-        supertokens_config,
-        recipe_list,
-        mode,
-        telemetry,
+        app_info, framework, supertokens_config, recipe_list, mode, telemetry, debug
     )
 
 

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.16.6"
+VERSION = "0.16.7"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/logger.py
+++ b/supertokens_python/logger.py
@@ -11,7 +11,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
 import json
 import logging
 from datetime import datetime
@@ -25,11 +24,16 @@ DEBUG_ENV_VAR = "SUPERTOKENS_DEBUG"
 
 supertokens_dir = path.dirname(__file__)
 
+
+def enable_debug_logging():
+    _logger.setLevel(logging.DEBUG)
+
+
 # Configure logger
 _logger = logging.getLogger(NAMESPACE)
 debug_env = getenv(DEBUG_ENV_VAR, "").lower()
 if debug_env == "1":
-    _logger.setLevel(logging.DEBUG)
+    enable_debug_logging()
 
 
 def _get_log_timestamp() -> str:

--- a/supertokens_python/supertokens.py
+++ b/supertokens_python/supertokens.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Unio
 
 from typing_extensions import Literal
 
-from supertokens_python.logger import get_maybe_none_as_str, log_debug_message
+from supertokens_python.logger import (
+    get_maybe_none_as_str,
+    log_debug_message,
+    enable_debug_logging,
+)
 
 from .constants import FDI_KEY_HEADER, RID_KEY_HEADER, USER_COUNT, USER_DELETE, USERS
 from .exceptions import SuperTokensError
@@ -150,6 +154,7 @@ class Supertokens:
         recipe_list: List[Callable[[AppInfo], RecipeModule]],
         mode: Optional[Literal["asgi", "wsgi"]],
         telemetry: Optional[bool],
+        debug: Optional[bool],
     ):
         if not isinstance(app_info, InputAppInfo):  # type: ignore
             raise ValueError("app_info must be an instance of InputAppInfo")
@@ -165,6 +170,9 @@ class Supertokens:
             mode,
         )
         self.supertokens_config = supertokens_config
+        self.debug = debug
+        if debug is True:
+            enable_debug_logging()
         self._telemetry_status: str = "NONE"
         log_debug_message(
             "Started SuperTokens with debug logging (supertokens.init called)"
@@ -217,6 +225,7 @@ class Supertokens:
         recipe_list: List[Callable[[AppInfo], RecipeModule]],
         mode: Optional[Literal["asgi", "wsgi"]],
         telemetry: Optional[bool],
+        debug: Optional[bool],
     ):
         if Supertokens.__instance is None:
             Supertokens.__instance = Supertokens(
@@ -226,6 +235,7 @@ class Supertokens:
                 recipe_list,
                 mode,
                 telemetry,
+                debug,
             )
             PostSTInitCallbacks.run_post_init_callbacks()
 

--- a/supertokens_python/supertokens.py
+++ b/supertokens_python/supertokens.py
@@ -170,7 +170,6 @@ class Supertokens:
             mode,
         )
         self.supertokens_config = supertokens_config
-        self.debug = debug
         if debug is True:
             enable_debug_logging()
         self._telemetry_status: str = "NONE"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,13 +1,38 @@
+import importlib
 import json
+import os
+import sys
 from datetime import datetime as real_datetime
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.constants import VERSION
 from supertokens_python.logger import log_debug_message, streamFormatter
+from supertokens_python.recipe import session
+
+from tests.utils import clean_st, reset, setup_st, start_st
 
 
 class LoggerTests(TestCase):
+    def setup_method(self, _):
+        self._caplog.clear()
+        reset()
+        clean_st()
+        setup_st()
+
+    def teardown_method(self, _):
+        self._caplog.clear()
+        reset()
+        clean_st()
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog: pytest.LogCaptureFixture):
+        # caplog is the pytest fixture to capture all logs
+        self._caplog = caplog  # pylint: disable=attribute-defined-outside-init
+
     @patch("supertokens_python.logger.datetime", wraps=real_datetime)
     def test_json_msg_format(self, datetime_mock: MagicMock):
         datetime_mock.utcnow.return_value = real_datetime(2000, 1, 1)  # type: ignore
@@ -22,7 +47,7 @@ class LoggerTests(TestCase):
             "t": "2000-01-01T00:00Z",
             "sdkVer": VERSION,
             "message": "API replied with status 200",
-            "file": "../tests/test_logger.py:16",
+            "file": "../tests/test_logger.py:40",
         }
 
     @staticmethod
@@ -31,3 +56,89 @@ class LoggerTests(TestCase):
             streamFormatter._fmt  # pylint: disable=protected-access
             == "{name} {message}\n"
         )
+
+    def test_logger_config_with_debug_true(self):
+        start_st()
+        init(
+            supertokens_config=SupertokensConfig("http://localhost:3567"),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="api.supertokens.io",
+                website_domain="supertokens.io",
+                api_base_path="/",
+            ),
+            framework="fastapi",
+            recipe_list=[session.init(anti_csrf="VIA_CUSTOM_HEADER")],
+            debug=True,
+        )
+
+        logMsg = "log test - valid log"
+        log_debug_message(logMsg)
+
+        assert logMsg in self._caplog.text
+
+    def test_logger_config_with_debug_false(self):
+        start_st()
+        init(
+            supertokens_config=SupertokensConfig("http://localhost:3567"),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="api.supertokens.io",
+                website_domain="supertokens.io",
+                api_base_path="/",
+            ),
+            framework="fastapi",
+            recipe_list=[session.init(anti_csrf="VIA_CUSTOM_HEADER")],
+            debug=False,
+        )
+
+        logMsg = "log test - valid log"
+        log_debug_message(logMsg)
+
+        assert logMsg not in self._caplog.text
+
+    def test_logger_config_with_debug_not_set(self):
+        start_st()
+        init(
+            supertokens_config=SupertokensConfig("http://localhost:3567"),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="api.supertokens.io",
+                website_domain="supertokens.io",
+                api_base_path="/",
+            ),
+            framework="fastapi",
+            recipe_list=[session.init(anti_csrf="VIA_CUSTOM_HEADER")],
+        )
+
+        logMsg = "log test - valid log"
+        log_debug_message(logMsg)
+
+        assert logMsg not in self._caplog.text
+
+    def test_logger_config_with_env_var(self):
+        os.environ["SUPERTOKENS_DEBUG"] = "1"
+
+        # environment variable was already set when the logger module was imported
+        # since its being changed for the test, the module needs to be reloaded.
+        importlib.reload(sys.modules["supertokens_python.logger"])
+        start_st()
+        init(
+            supertokens_config=SupertokensConfig("http://localhost:3567"),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="api.supertokens.io",
+                website_domain="supertokens.io",
+                api_base_path="/",
+            ),
+            framework="fastapi",
+            recipe_list=[session.init(anti_csrf="VIA_CUSTOM_HEADER")],
+        )
+
+        logMsg = "log test - valid log"
+        log_debug_message(logMsg)
+
+        # Unset the environment variable
+        del os.environ["SUPERTOKENS_DEBUG"]
+
+        assert logMsg in self._caplog.text

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+import logging
 import os
 import sys
 from datetime import datetime as real_datetime
@@ -10,15 +11,26 @@ import pytest
 
 from supertokens_python import InputAppInfo, SupertokensConfig, init
 from supertokens_python.constants import VERSION
-from supertokens_python.logger import log_debug_message, streamFormatter
+from supertokens_python.logger import (
+    log_debug_message,
+    streamFormatter,
+    NAMESPACE,
+    enable_debug_logging,
+)
 from supertokens_python.recipe import session
 
 from tests.utils import clean_st, reset, setup_st, start_st
 
 
 class LoggerTests(TestCase):
-    def setup_method(self, _):
-        self._caplog.clear()
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog: pytest.LogCaptureFixture):
+        # caplog is the pytest fixture to capture all logs
+        self._caplog = caplog  # pylint: disable=attribute-defined-outside-init
+
+    def setup_method(self, _):  # pylint: disable=no-self-use
+        # Setting the log level to a higher level so debug logs are not printed
+        logging.getLogger(NAMESPACE).setLevel(logging.ERROR)
         reset()
         clean_st()
         setup_st()
@@ -28,13 +40,9 @@ class LoggerTests(TestCase):
         reset()
         clean_st()
 
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog: pytest.LogCaptureFixture):
-        # caplog is the pytest fixture to capture all logs
-        self._caplog = caplog  # pylint: disable=attribute-defined-outside-init
-
     @patch("supertokens_python.logger.datetime", wraps=real_datetime)
-    def test_json_msg_format(self, datetime_mock: MagicMock):
+    def test_1_json_msg_format(self, datetime_mock: MagicMock):
+        enable_debug_logging()
         datetime_mock.utcnow.return_value = real_datetime(2000, 1, 1)  # type: ignore
 
         with self.assertLogs(level="DEBUG") as captured:
@@ -47,37 +55,17 @@ class LoggerTests(TestCase):
             "t": "2000-01-01T00:00Z",
             "sdkVer": VERSION,
             "message": "API replied with status 200",
-            "file": "../tests/test_logger.py:40",
+            "file": "../tests/test_logger.py:49",
         }
 
     @staticmethod
-    def test_stream_formatter_format():
+    def test_2_stream_formatter_format():
         assert (
             streamFormatter._fmt  # pylint: disable=protected-access
             == "{name} {message}\n"
         )
 
-    def test_logger_config_with_debug_true(self):
-        start_st()
-        init(
-            supertokens_config=SupertokensConfig("http://localhost:3567"),
-            app_info=InputAppInfo(
-                app_name="SuperTokens Demo",
-                api_domain="api.supertokens.io",
-                website_domain="supertokens.io",
-                api_base_path="/",
-            ),
-            framework="fastapi",
-            recipe_list=[session.init(anti_csrf="VIA_CUSTOM_HEADER")],
-            debug=True,
-        )
-
-        logMsg = "log test - valid log"
-        log_debug_message(logMsg)
-
-        assert logMsg in self._caplog.text
-
-    def test_logger_config_with_debug_false(self):
+    def test_3_logger_config_with_debug_false(self):
         start_st()
         init(
             supertokens_config=SupertokensConfig("http://localhost:3567"),
@@ -97,7 +85,27 @@ class LoggerTests(TestCase):
 
         assert logMsg not in self._caplog.text
 
-    def test_logger_config_with_debug_not_set(self):
+    def test_4_logger_config_with_debug_true(self):
+        start_st()
+        init(
+            supertokens_config=SupertokensConfig("http://localhost:3567"),
+            app_info=InputAppInfo(
+                app_name="SuperTokens Demo",
+                api_domain="api.supertokens.io",
+                website_domain="supertokens.io",
+                api_base_path="/",
+            ),
+            framework="fastapi",
+            recipe_list=[session.init(anti_csrf="VIA_CUSTOM_HEADER")],
+            debug=True,
+        )
+
+        logMsg = "log test - valid log"
+        log_debug_message(logMsg)
+
+        assert logMsg in self._caplog.text
+
+    def test_5_logger_config_with_debug_not_set(self):
         start_st()
         init(
             supertokens_config=SupertokensConfig("http://localhost:3567"),
@@ -116,7 +124,7 @@ class LoggerTests(TestCase):
 
         assert logMsg not in self._caplog.text
 
-    def test_logger_config_with_env_var(self):
+    def test_6_logger_config_with_env_var(self):
         os.environ["SUPERTOKENS_DEBUG"] = "1"
 
         # environment variable was already set when the logger module was imported


### PR DESCRIPTION
## Summary of change

Added debug flag in the SuperTokenConfig in the init() for logging

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

Added unit tests.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR


