### PR TITLE
fix: Incompatibility with django 4.0 and higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.18.5] - 2023-12-14
+
+- Fixes an incompatibility issue with Django version 4.0 and above.
+
 ## [0.18.4] - 2023-12-12
 
 - CI/CD changes

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.18.4",
+    version="0.18.5",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.18.4"
+VERSION = "0.18.5"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/framework/django/django_request.py
+++ b/supertokens_python/framework/django/django_request.py
@@ -30,7 +30,7 @@ class DjangoRequest(BaseRequest):
         self.request = request
 
     def get_original_url(self) -> str:
-        return self.request.get_raw_uri()
+        return self.request.build_absolute_uri()
 
     def get_query_param(
         self, key: str, default: Union[str, None] = None


### PR DESCRIPTION
## Summary of change

`get_raw_uri` method was removed from [Django v4](https://django.readthedocs.io/en/stable/releases/4.0.html) but our SDK was still using it. I have replaced that method by `build_absolute_uri` as suggested in the changelog.  


## Test Plan

Delete User API was breaking on user dashboard because of this issue. I tested it manually after doing this change.


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
