### PR TITLE
fix: relax constraint on aiosmtplib lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.18.10] - 2024-04-05
+
+- Relax constraints on `aiosmtplib` dependency version.
 
 ## [0.18.9] - 2024-03-14
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-aiosmtplib>=1.1.6,<=3.0.1
+aiosmtplib>=1.1.6,<4.0.0
 anyio==3.5.0
 asgiref==3.5.2
 astroid==2.9.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-aiosmtplib==1.1.6
+aiosmtplib>=1.1.6,<=3.0.1
 anyio==3.5.0
 asgiref==3.5.2
 astroid==2.9.3

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
         "Deprecated==1.2.13",
         "phonenumbers==8.12.48",
         "twilio==7.9.1",
-        "aiosmtplib>=1.1.6,<=3.0.1",
+        "aiosmtplib>=1.1.6,<4.0.0",
         "pkce==1.0.3",
     ],
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.18.9",
+    version="0.18.10",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",
@@ -110,7 +110,7 @@ setup(
         "Deprecated==1.2.13",
         "phonenumbers==8.12.48",
         "twilio==7.9.1",
-        "aiosmtplib==1.1.6",
+        "aiosmtplib>=1.1.6,<=3.0.1",
         "pkce==1.0.3",
     ],
     python_requires=">=3.7",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.18.9"
+VERSION = "0.18.10"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/ingredients/emaildelivery/services/smtp.py
+++ b/supertokens_python/ingredients/emaildelivery/services/smtp.py
@@ -37,15 +37,17 @@ class Transporter:
             if self.smtp_settings.secure:
                 # Use TLS from the beginning
                 mail = aiosmtplib.SMTP(
-                    self.smtp_settings.host,
-                    self.smtp_settings.port,
+                    hostname=self.smtp_settings.host,
+                    port=self.smtp_settings.port,
                     use_tls=True,
                     tls_context=tls_context,
                 )
             else:
                 # Start without TLS (but later try upgrading)
                 mail = aiosmtplib.SMTP(
-                    self.smtp_settings.host, self.smtp_settings.port, use_tls=False
+                    hostname=self.smtp_settings.host,
+                    port=self.smtp_settings.port,
+                    use_tls=False,
                 )
 
             await mail.connect()  # type: ignore


### PR DESCRIPTION
## Summary of change

This PR relaxes constraint on `aiosmtplib` library. 

## Related issues

- https://github.com/supertokens/supertokens-python/issues/481

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

