### PR TITLE
fix: normalise_session_scope and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.18.12] - 2024-05-01
+
+- Fixed a bug in the `normalise_session_scope` util function that caused it to remove leading dots from the scope string.
+
 ## [0.18.11] - 2024-04-26
 
 - Fixes issues with the propagation of session creation/updates with django-rest-framework because the django-rest-framework wrapped the original request with it's own request object. Updates on that object were not reflecting on the original request object.

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.18.11",
+    version="0.18.12",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.18.11"
+VERSION = "0.18.12"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/session/utils.py
+++ b/supertokens_python/recipe/session/utils.py
@@ -67,19 +67,16 @@ def normalise_session_scope(session_scope: str) -> str:
                 raise Exception("Should not come here")
             scope = url_obj.hostname
 
-            if scope.startswith("."):
-                scope = scope[1:]
-
             return scope
         except Exception:
-            raise_general_exception("Please provide a valid sessionScope")
+            raise_general_exception("Please provide a valid session_scope")
 
     no_dot_normalised = helper(session_scope)
     if no_dot_normalised == "localhost" or is_an_ip_address(no_dot_normalised):
         return no_dot_normalised
 
-    if no_dot_normalised[0] == ".":
-        return no_dot_normalised[1:]
+    if session_scope.startswith("."):
+        return "." + no_dot_normalised
 
     return no_dot_normalised
 

--- a/tests/sessions/test_session_utils.py
+++ b/tests/sessions/test_session_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from supertokens_python.recipe.session.utils import normalise_session_scope
+
+
+class TestNormaliseSessionScope:
+    def test_with_leading_dot(self):
+        result = normalise_session_scope(".example.com")
+        assert result == ".example.com"
+
+    def test_without_leading_dot(self):
+        result = normalise_session_scope("example.com")
+        assert result == "example.com"
+
+    def test_with_http_prefix(self):
+        result = normalise_session_scope("http://example.com")
+        assert result == "example.com"
+
+    def test_with_https_prefix(self):
+        result = normalise_session_scope("https://example.com")
+        assert result == "example.com"
+
+    def test_with_ip_address(self):
+        result = normalise_session_scope("192.168.1.1")
+        assert result == "192.168.1.1"
+
+    def test_with_localhost(self):
+        result = normalise_session_scope("localhost")
+        assert result == "localhost"
+
+    def test_with_leading_trailing_whitespace(self):
+        result = normalise_session_scope("  example.com  ")
+        assert result == "example.com"


### PR DESCRIPTION
## Summary of change

Fixes the `normalise_session_scope` function and adds tests for it.

## Related issues

-   https://github.com/supertokens/supertokens-golang/pull/410
-   https://github.com/supertokens/supertokens-node/pull/825


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core