### PR TITLE
test: move the session object and claims to the BE sdk server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.23.1] - 2024-07-09
+
+### Changes
+
+-   `refresh_post` and `refresh_session` now clears all user tokens upon CSRF failures and if no tokens are found. See the latest comment on https://github.com/supertokens/supertokens-node/issues/141 for more details.
+
 ## [0.23.0] - 2024-06-24
 
 ### Breaking change

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.23.0",
+    version="0.23.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.23.0"
+VERSION = "0.23.1"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/session/session_request_functions.py
+++ b/supertokens_python/recipe/session/session_request_functions.py
@@ -439,7 +439,7 @@ async def refresh_session_in_request(
 
         return raise_unauthorised_exception(
             "Refresh token not found. Are you sending the refresh token in the request?",
-            clear_tokens=False,
+            clear_tokens=True,
             response_mutators=response_mutators,
         )
 
@@ -460,7 +460,7 @@ async def refresh_session_in_request(
             # see https://github.com/supertokens/supertokens-node/issues/141
             raise_unauthorised_exception(
                 "anti-csrf check failed. Please pass 'rid: \"session\"' header in the request.",
-                clear_tokens=False,
+                clear_tokens=True,
             )
         disable_anti_csrf = True
 

--- a/tests/sessions/test_auth_mode.py
+++ b/tests/sessions/test_auth_mode.py
@@ -475,15 +475,15 @@ async def test_should_update_acccess_token_payload(
 @mark.parametrize(
     "transfer_method, auth_header, auth_cookie, output, set_tokens, cleared_tokens",
     [
-        ("any", False, False, "unauthorised", None, None),
-        ("header", False, False, "unauthorised", None, None),
-        ("cookie", False, False, "unauthorised", None, None),
+        ("any", False, False, "unauthorised", None, "both"),
+        ("header", False, False, "unauthorised", None, "both"),
+        ("cookie", False, False, "unauthorised", None, "both"),
         ("any", False, True, "validatecookie", "cookies", None),
-        ("header", False, True, "unauthorised", None, None),
+        ("header", False, True, "unauthorised", None, "both"),
         ("cookie", False, True, "validatecookie", "cookies", None),
         ("any", True, False, "validateheader", "headers", None),
         ("header", True, False, "validateheader", "headers", None),
-        ("cookie", True, False, "unauthorised", None, None),
+        ("cookie", True, False, "unauthorised", None, "both"),
         ("any", True, True, "validateheader", "headers", "cookies"),
         ("header", True, True, "validateheader", "headers", "cookies"),
         ("cookie", True, True, "validatecookie", "cookies", "headers"),
@@ -544,6 +544,18 @@ async def test_refresh_session_parametrized(
             refresh_result["sRefreshToken"]["expires"]
             == "Thu, 01 Jan 1970 00:00:00 GMT"
         )
+    elif cleared_tokens == "both":
+        assert refresh_result["accessTokenFromHeader"] == ""
+        assert refresh_result["refreshTokenFromHeader"] == ""
+        assert refresh_result["accessToken"] == ""
+        assert (
+            refresh_result["sAccessToken"]["expires"] == "Thu, 01 Jan 1970 00:00:00 GMT"
+        )
+        assert refresh_result["refreshToken"] == ""
+        assert (
+            refresh_result["sRefreshToken"]["expires"]
+            == "Thu, 01 Jan 1970 00:00:00 GMT"
+        )
 
     if set_tokens == "headers":
         assert refresh_result["accessTokenFromHeader"] != ""
@@ -565,12 +577,13 @@ async def test_refresh_session_parametrized(
     else:
         assert False, "Invalid set_tokens value"
 
-    if set_tokens != "cookies" and cleared_tokens != "cookies":
-        assert refresh_result["accessToken"] is None
-        assert refresh_result["refreshToken"] is None
-    elif set_tokens != "headers" and cleared_tokens != "headers":
-        assert refresh_result["accessTokenFromHeader"] is None
-        assert refresh_result["refreshTokenFromHeader"] is None
+    if cleared_tokens != "both":
+        if set_tokens != "cookies" and cleared_tokens != "cookies":
+            assert refresh_result["accessToken"] is None
+            assert refresh_result["refreshToken"] is None
+        elif set_tokens != "headers" and cleared_tokens != "headers":
+            assert refresh_result["accessTokenFromHeader"] is None
+            assert refresh_result["refreshTokenFromHeader"] is None
 
 
 async def refresh_session(


### PR DESCRIPTION
## Summary of change

test: move the session object and claims to the BE sdk server

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [x] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [x] Make sure that `syncio` / `asyncio` functions are consistent.
-   [x] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
