### PR TITLE
fix: Add support for any type in value field instead of only string

### DIFF
--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -23,6 +23,8 @@ jobs:
               run: |
                 python3 -m venv venv
                 source venv/bin/activate
+                pip install "cython<3.0.0" wheel
+                pip install "PyYAML==5.4.1" --no-build-isolation
                 make dev-install && rm -rf src
             - name: Make a dummy change to README.md
               run: |

--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -12,7 +12,6 @@ jobs:
     pr-title:
         name: Pre commit hook check
         runs-on: ubuntu-latest
-        # container: rishabhpoddar/supertokens_python_driver_testing
         steps:
             - uses: actions/checkout@v2
             - name: Set up node

--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -19,10 +19,16 @@ jobs:
               uses: actions/setup-node@v1
               with:
                 node-version: '12'
+            - name: Create virtual environment and install dependencies
+              run: |
+                python3 -m venv venv
+                source venv/bin/activate
+                make dev-install && rm -rf src
             - name: Make a dummy change to README.md
               run: |
                 echo "# Dummy change for PR check" >> README.md
             - run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
-            - run: make dev-install && rm -rf src
-            - run: ./hooks/pre-commit.sh
+            - run: |
+                source venv/bin/activate
+                ./hooks/pre-commit.sh
              

--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -12,12 +12,8 @@ jobs:
     pr-title:
         name: Pre commit hook check
         runs-on: ubuntu-latest
-        container: rishabhpoddar/supertokens_python_driver_testing
+        # container: rishabhpoddar/supertokens_python_driver_testing
         steps:
-            - name: Install required GLIBC
-              run: |
-                apt-get update && \
-                apt-get install -y --no-install-recommends g++ make zlib1g-dev libc6
             - uses: actions/checkout@v2
             - name: Set up node
               uses: actions/setup-node@v1

--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -19,6 +19,9 @@ jobs:
               uses: actions/setup-node@v1
               with:
                 node-version: '12'
+            - name: Make a dummy change to README.md
+              run: |
+                echo "# Dummy change for PR check" >> README.md
             - run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
             - run: make dev-install && rm -rf src
             - run: ./hooks/pre-commit.sh

--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -14,11 +14,15 @@ jobs:
         runs-on: ubuntu-latest
         container: rishabhpoddar/supertokens_python_driver_testing
         steps:
+            - name: Install required GLIBC
+              run: |
+                apt-get update && \
+                apt-get install -y --no-install-recommends g++ make zlib1g-dev libc6
             - uses: actions/checkout@v2
             - name: Set up node
               uses: actions/setup-node@v1
               with:
-                node-version: '16'
+                node-version: '12'
             - run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
             - run: make dev-install && rm -rf src
             - run: ./hooks/pre-commit.sh

--- a/.github/workflows/pre-commit-hook-run.yml
+++ b/.github/workflows/pre-commit-hook-run.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v1
               with:
-                node-version: '12'
+                node-version: '16'
             - run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
             - run: make dev-install && rm -rf src
             - run: ./hooks/pre-commit.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.24.3] - 2024-09-24
+
+- Adds support for form field related improvements by making fields accept any type of values
+- Adds support for optional fields to properly optional
+
 ## [0.24.2] - 2024-09-03
 - Makes optional input form fields truly optional instead of just being able to accept `""`.
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.24.2",
+    version="0.24.3",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["3.0"]
-VERSION = "0.24.2"
+VERSION = "0.24.3"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/emailpassword/api/utils.py
+++ b/supertokens_python/recipe/emailpassword/api/utils.py
@@ -41,7 +41,9 @@ async def validate_form_or_throw_error(
         input_field: Union[None, FormField] = find_first_occurrence_in_list(
             lambda x: x.id == field.id, inputs
         )
-        is_invalid_value = input_field is None or input_field.value == ""
+        is_invalid_value = input_field is None or (
+            isinstance(input_field.value, str) and input_field.value == ""
+        )
         if not field.optional and is_invalid_value:
             validation_errors.append(ErrorFormField(field.id, "Field is not optional"))
             continue

--- a/supertokens_python/recipe/emailpassword/api/utils.py
+++ b/supertokens_python/recipe/emailpassword/api/utils.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 from typing import Any, Dict, List, Union
 
 from supertokens_python.exceptions import raise_bad_input_exception
-from supertokens_python.recipe.emailpassword.constants import FORM_FIELD_EMAIL_ID
+from supertokens_python.recipe.emailpassword.constants import (
+    FORM_FIELD_EMAIL_ID,
+    FORM_FIELD_PASSWORD_ID,
+)
 from supertokens_python.recipe.emailpassword.exceptions import (
     raise_form_field_exception,
 )
@@ -85,7 +88,18 @@ async def validate_form_fields_or_throw_error(
             raise_bad_input_exception(
                 "All elements of formFields must contain an 'id' and 'value' field"
             )
+
         value = current_form_field["value"]
+        if current_form_field["id"] in [
+            FORM_FIELD_EMAIL_ID,
+            FORM_FIELD_PASSWORD_ID,
+        ] and not isinstance(value, str):
+            # Ensure that the type is string else we will throw a bad input
+            # error.
+            raise_bad_input_exception(
+                f"{current_form_field['id']} value must be a string"
+            )
+
         if current_form_field["id"] == FORM_FIELD_EMAIL_ID and isinstance(value, str):
             value = value.strip()
         form_fields.append(FormField(current_form_field["id"], value))

--- a/supertokens_python/recipe/emailpassword/types.py
+++ b/supertokens_python/recipe/emailpassword/types.py
@@ -12,7 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from __future__ import annotations
-from typing import Awaitable, Callable, List, TypeVar, Union
+
+from typing import Any, Awaitable, Callable, List, TypeVar, Union
 
 from supertokens_python.ingredients.emaildelivery import EmailDeliveryIngredient
 from supertokens_python.ingredients.emaildelivery.types import (
@@ -53,9 +54,9 @@ class ErrorFormField:
 
 
 class FormField:
-    def __init__(self, id: str, value: str):  # pylint: disable=redefined-builtin
+    def __init__(self, id: str, value: Any):  # pylint: disable=redefined-builtin
         self.id: str = id
-        self.value: str = value
+        self.value: Any = value
 
 
 class InputFormField:

--- a/supertokens_python/recipe/emailpassword/utils.py
+++ b/supertokens_python/recipe/emailpassword/utils.py
@@ -258,15 +258,8 @@ def validate_and_normalise_user_input(
     email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
 ) -> EmailPasswordConfig:
 
-    # type: ignore
-    if sign_up_feature is not None and not isinstance(
-        sign_up_feature, InputSignUpFeature
-    ):
-        raise ValueError("sign_up_feature must be of type InputSignUpFeature or None")
-
-    # type: ignore
-    if override is not None and not isinstance(override, InputOverrideConfig):
-        raise ValueError("override must be of type InputOverrideConfig or None")
+    # NOTE: We don't need to check the instance of sign_up_feature and override
+    # as they will always be either None or the specified type.
 
     if override is None:
         override = InputOverrideConfig()

--- a/supertokens_python/recipe/emailpassword/utils.py
+++ b/supertokens_python/recipe/emailpassword/utils.py
@@ -14,9 +14,9 @@
 from __future__ import annotations
 
 from re import fullmatch
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union, Dict
-from supertokens_python.framework import BaseRequest
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
+from supertokens_python.framework import BaseRequest
 from supertokens_python.ingredients.emaildelivery.types import (
     EmailDeliveryConfig,
     EmailDeliveryConfigWithService,
@@ -26,17 +26,14 @@ from supertokens_python.recipe.emailpassword.emaildelivery.services.backward_com
 )
 
 from .interfaces import APIInterface, RecipeInterface
-from .types import InputFormField, NormalisedFormField, EmailTemplateVars
+from .types import EmailTemplateVars, InputFormField, NormalisedFormField
 
 if TYPE_CHECKING:
     from supertokens_python.supertokens import AppInfo
 
 from supertokens_python.utils import get_filtered_list
 
-from .constants import (
-    FORM_FIELD_EMAIL_ID,
-    FORM_FIELD_PASSWORD_ID,
-)
+from .constants import FORM_FIELD_EMAIL_ID, FORM_FIELD_PASSWORD_ID
 
 
 async def default_validator(_: str, __: str) -> Union[str, None]:
@@ -261,10 +258,14 @@ def validate_and_normalise_user_input(
     email_delivery: Union[EmailDeliveryConfig[EmailTemplateVars], None] = None,
 ) -> EmailPasswordConfig:
 
-    if sign_up_feature is not None and not isinstance(sign_up_feature, InputSignUpFeature):  # type: ignore
+    # type: ignore
+    if sign_up_feature is not None and not isinstance(
+        sign_up_feature, InputSignUpFeature
+    ):
         raise ValueError("sign_up_feature must be of type InputSignUpFeature or None")
 
-    if override is not None and not isinstance(override, InputOverrideConfig):  # type: ignore
+    # type: ignore
+    if override is not None and not isinstance(override, InputOverrideConfig):
         raise ValueError("override must be of type InputOverrideConfig or None")
 
     if override is None:

--- a/tests/emailpassword/test_signin.py
+++ b/tests/emailpassword/test_signin.py
@@ -720,6 +720,48 @@ async def test_optional_custom_field_without_input(driver_config_client: TestCli
 
 
 @mark.asyncio
+async def test_non_optional_custom_field_with_boolean_value(
+    driver_config_client: TestClient,
+):
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="http://api.supertokens.io",
+            website_domain="http://supertokens.io",
+            api_base_path="/auth",
+        ),
+        framework="fastapi",
+        recipe_list=[
+            emailpassword.init(
+                sign_up_feature=emailpassword.InputSignUpFeature(
+                    form_fields=[
+                        emailpassword.InputFormField("autoVerify", optional=False)
+                    ]
+                )
+            ),
+            session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+        ],
+    )
+    start_st()
+
+    response_1 = driver_config_client.post(
+        url="/auth/signup",
+        headers={"Content-Type": "application/json"},
+        json={
+            "formFields": [
+                {"id": "email", "value": "random@gmail.com"},
+                {"id": "password", "value": "validpassword123"},
+                {"id": "autoVerify", "value": False},
+            ]
+        },
+    )
+    assert response_1.status_code == 200
+    dict_response = json.loads(response_1.text)
+    assert dict_response["status"] == "OK"
+
+
+@mark.asyncio
 async def test_too_many_fields(driver_config_client: TestClient):
     init(
         supertokens_config=SupertokensConfig("http://localhost:3567"),

--- a/tests/emailpassword/test_signin.py
+++ b/tests/emailpassword/test_signin.py
@@ -762,6 +762,85 @@ async def test_non_optional_custom_field_with_boolean_value(
 
 
 @mark.asyncio
+async def test_invalid_type_for_email_and_password(
+    driver_config_client: TestClient,
+):
+    init(
+        supertokens_config=SupertokensConfig("http://localhost:3567"),
+        app_info=InputAppInfo(
+            app_name="SuperTokens Demo",
+            api_domain="http://api.supertokens.io",
+            website_domain="http://supertokens.io",
+            api_base_path="/auth",
+        ),
+        framework="fastapi",
+        recipe_list=[
+            emailpassword.init(
+                sign_up_feature=emailpassword.InputSignUpFeature(form_fields=[])
+            ),
+            session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+        ],
+    )
+    start_st()
+
+    response_1 = driver_config_client.post(
+        url="/auth/signup",
+        headers={"Content-Type": "application/json"},
+        json={
+            "formFields": [
+                {"id": "email", "value": 123},
+                {"id": "password", "value": "validpassword123"},
+            ]
+        },
+    )
+    assert response_1.status_code == 400
+    dict_response = json.loads(response_1.text)
+    assert dict_response["message"] == "email value must be a string"
+
+    response_1_signin = driver_config_client.post(
+        url="/auth/signin",
+        headers={"Content-Type": "application/json"},
+        json={
+            "formFields": [
+                {"id": "email", "value": 123},
+                {"id": "password", "value": "validpassword123"},
+            ]
+        },
+    )
+    assert response_1_signin.status_code == 400
+    dict_response_signin = json.loads(response_1_signin.text)
+    assert dict_response_signin["message"] == "email value must be a string"
+
+    response_2 = driver_config_client.post(
+        url="/auth/signup",
+        headers={"Content-Type": "application/json"},
+        json={
+            "formFields": [
+                {"id": "email", "value": "random@gmail.com"},
+                {"id": "password", "value": 12345},
+            ]
+        },
+    )
+    assert response_2.status_code == 400
+    dict_response = json.loads(response_2.text)
+    assert dict_response["message"] == "password value must be a string"
+
+    response_2_signin = driver_config_client.post(
+        url="/auth/signin",
+        headers={"Content-Type": "application/json"},
+        json={
+            "formFields": [
+                {"id": "email", "value": "random@gmail.com"},
+                {"id": "password", "value": 12345},
+            ]
+        },
+    )
+    assert response_2_signin.status_code == 400
+    dict_response_signin = json.loads(response_2_signin.text)
+    assert dict_response_signin["message"] == "password value must be a string"
+
+
+@mark.asyncio
 async def test_too_many_fields(driver_config_client: TestClient):
     init(
         supertokens_config=SupertokensConfig("http://localhost:3567"),

--- a/tests/emailpassword/test_signup.py
+++ b/tests/emailpassword/test_signup.py
@@ -11,19 +11,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from fastapi import FastAPI
 import json
-from tests.testclient import TestClientWithNoCookieJar as TestClient
+
+from fastapi import FastAPI
 from pytest import fixture, mark
+
 from supertokens_python import init
 from supertokens_python.framework.fastapi import get_middleware
 from supertokens_python.recipe import emailpassword, session
+from tests.testclient import TestClientWithNoCookieJar as TestClient
 from tests.utils import (
     get_st_init_args,
     setup_function,
+    sign_up_request,
     start_st,
     teardown_function,
-    sign_up_request,
 )
 
 _ = setup_function  # type: ignore


### PR DESCRIPTION
## Summary of change

Port for form validation changes to support any type of value in form fields instead of just strings.

Reference PR: https://github.com/supertokens/supertokens-node/pull/924

> PS: This also includes some fixes for the pre-commit hook workflow that was failing to run earlier.

## Related issues

## Test Plan

All tests in authFlow, passwordReset should pass

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core
