### PR TITLE
Fix uncaught exception in `session_exception_handler` for fastapi>0.77.0

### DIFF
--- a/supertokens_python/recipe/session/framework/fastapi/__init__.py
+++ b/supertokens_python/recipe/session/framework/fastapi/__init__.py
@@ -81,7 +81,7 @@ async def session_exception_handler(
     Usage: `app.add_exception_handler(SuperTokensError, st_exception_handler)`
     """
     base_req = FastApiRequest(request)
-    base_res = FastApiResponse(JSONResponse())
+    base_res = FastApiResponse(JSONResponse(None))
     user_context = default_user_context(base_req)
     result = await Supertokens.get_instance().handle_supertokens_error(
         base_req, exc, base_res, user_context


### PR DESCRIPTION
## Summary of change

This PR makes this project compatible with fastapi versions later than 0.77.0, form which on a `content` arg is required when instantiating `JSONResponses`. [See the change log](https://fastapi.tiangolo.com/release-notes/#0770).

## Related issues

-   #530 

## Test Plan

I'm not sure how to test this, since I can't this project to run locally. This seems to be primarily related with some outdated dependencies.

## Documentation changes

Since this change restores expected behavior, I assume this is not required.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

