### PR TITLE
feat: allow disabling `tldextract` HTTP requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__
 releasePassword
 apiPassword
 venv/
-env/
+./env/
 .env
 .DS_Store
 bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [unreleased]
-- Upgrades `pip` and `setuptools` in CI publish job
-- Also upgrades `poetry` and it's dependency - `clikit`
 
 ## [0.29.0] - 2025-03-03
+- Adds option to disable `tldextract` HTTP calls by setting `SUPERTOKENS_TLDEXTRACT_DISABLE_HTTP=1`
+- Upgrades `pip` and `setuptools` in CI publish job
+  - Also upgrades `poetry` and it's dependency - `clikit`
 - Migrates unit tests to use a containerized core
   - Updates `Makefile` to use a Docker `compose` setup step
   - Migrates unit tests from CircleCI to Github Actions

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ flask-cors==5.0.0
 nest-asyncio==1.6.0
 pdoc3==0.11.0
 pre-commit==3.5.0
+pyfakefs==5.7.4
 pylint==3.2.7
 pyright==1.1.393
 python-dotenv==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         "PyJWT[crypto]>=2.5.0,<3.0.0",
         "httpx>=0.15.0,<1.0.0",
         "pycryptodome<3.21.0",
-        "tldextract<5.1.3",
+        "tldextract<6.0.0",
         "asgiref>=3.4.1,<4",
         "typing_extensions>=4.1.1,<5.0.0",
         "Deprecated<1.3.0",

--- a/supertokens_python/env/base.py
+++ b/supertokens_python/env/base.py
@@ -1,0 +1,12 @@
+from os import environ
+
+from supertokens_python.env.utils import str_to_bool
+
+
+def FLAG_tldextract_disable_http():
+    """
+    Disable HTTP calls from `tldextract`.
+    """
+    val = environ.get("SUPERTOKENS_TLDEXTRACT_DISABLE_HTTP", "0")
+
+    return str_to_bool(val)

--- a/supertokens_python/env/utils.py
+++ b/supertokens_python/env/utils.py
@@ -1,0 +1,5 @@
+def str_to_bool(val: str) -> bool:
+    """
+    Convert ENV values to boolean
+    """
+    return val.lower() in ("true", "t", "1")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@ import json
 
 # Import AsyncMock
 import sys
+from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
 from http.cookies import SimpleCookie
@@ -487,3 +488,17 @@ async def create_users(
             await manually_create_or_update_user(
                 "public", user["provider"], user["userId"], user["email"], True, None
             )
+
+
+@contextmanager
+def outputs(val: Any):
+    """
+    Outputs a value to assert.
+
+    Usage:
+        @mark.parametrize(["input", "expectation"], [(1, outputs(1)), (0, raises(Exception))])
+        def test_fn(input, expectation):
+            with expectation as expected_output:
+                assert 1 / input == expected_output
+    """
+    yield val


### PR DESCRIPTION
## Summary of change

- Workaround till tldextract#233 is implemented
- Adds flag to control disabling HTTP requests
- Adds `pyfakefs` to use in tests

## Related issues

- closes #562

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR
