### PR TITLE
build: bump `httpx`/`respx` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.28.1] - 2025-02-26
+- Pins `httpx` and `respx` to current major versions (<1.0.0)
+- Removes `respx` dependency from `fastapi` install
+
 ## [0.28.0]
 - **[Breaking] Updates pre-commit hooks to use `pre-commit`**
   - Migration:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,6 +18,6 @@ pytest-mock==3.14.0
 pytest-rerunfailures==14.0
 pyyaml==6.0.2
 requests-mock==1.12.1
-respx==0.21.1
+respx>=0.13.0, <1.0.0
 uvicorn==0.32.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ extras_require = {
     # on changes in these frameworks
     "fastapi": (
         [
-            "respx==0.21.1",
             "fastapi",
             "uvicorn",
             "python-dotenv==1.0.1",
@@ -83,7 +82,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.28.0",
+    version="0.28.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",
@@ -116,7 +115,7 @@ setup(
         # [crypto] ensures that it installs the `cryptography` library as well
         # based on constraints specified in https://github.com/jpadilla/pyjwt/blob/master/setup.cfg#L50
         "PyJWT[crypto]>=2.5.0,<3.0.0",
-        "httpx>=0.15.0,<=0.27.2",
+        "httpx>=0.15.0,<1.0.0",
         "pycryptodome<3.21.0",
         "tldextract<5.1.3",
         "asgiref>=3.4.1,<4",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["5.2"]
-VERSION = "0.28.0"
+VERSION = "0.28.1"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"


### PR DESCRIPTION
- Pins `httpx`/`respx` to current major versions (<1.0.0)
- Will allow users to update their dependencies without us having to keep up
- Fixes broken tests due to latest `httpx` changes
- Removes `respx` dependency from `fastapi` install
  - `fastapi` has no dependency on `respx`
  - We only use `respx` in tests
- Bump version to `0.28.1`

## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
