### PR TITLE
fix: validate MFA claim before allowing TOTP device removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.29.1] - 2025-04-11
+- Fixes an issue where `removeDevice` API allowed removing TOTP devices without the user completing MFA.
+
 ## [0.29.0] - 2025-03-03
 ### Breaking changes
 - Makes URL path normalization case sensitive

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.29.0",
+    version="0.29.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["5.2"]
-VERSION = "0.29.0"
+VERSION = "0.29.1"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/recipe/totp/api/remove_device.py
+++ b/supertokens_python/recipe/totp/api/remove_device.py
@@ -35,7 +35,9 @@ async def handle_remove_device_api(
 
     session = await get_session(
         api_options.request,
-        override_global_claim_validators=lambda _, __, ___: [],
+        override_global_claim_validators=lambda global_claim_validators, __, ___: [
+            gcv for gcv in global_claim_validators if gcv.id == "st-mfa"
+        ],
         session_required=True,
         user_context=user_context,
     )

--- a/tests/test-server/test_functions_mapper.py
+++ b/tests/test-server/test_functions_mapper.py
@@ -142,6 +142,10 @@ def get_func(eval_str: str) -> Callable[..., Any]:
                 required_secondary_factors_for_tenant: Any,
                 user_context: Dict[str, Any],
             ) -> MFARequirementList:
+                # Test specifies an override, return the required data
+                if 'getMFARequirementsForAuth:async()=>["totp"]' in eval_str:
+                    return ["totp"]
+
                 return ["otp-phone"] if user_context.get("requireFactor") else []
 
             original_implementation.get_mfa_requirements_for_auth = (


### PR DESCRIPTION
## Summary of change

- Fixes an issue where `removeDevice` API allowed removing TOTP devices without the user completing MFA.

## Related issues

- https://github.com/supertokens/supertokens-node/pull/962

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR
