### PR TITLE
fix: check for MFA claim in removeDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ## [0.29.1] - 2025-04-11
-- Fixes an issue where `removeDevice` API allowed removing TOTP devices without the user completing MFA.
+- Fixes an issue where `removeDevice` API allowed removing verified TOTP devices without the user completing MFA.
 - Fixes issue with ThirdParty provider info on dashboard
 
 ## [0.29.0] - 2025-03-03

--- a/supertokens_python/recipe/totp/api/remove_device.py
+++ b/supertokens_python/recipe/totp/api/remove_device.py
@@ -35,9 +35,7 @@ async def handle_remove_device_api(
 
     session = await get_session(
         api_options.request,
-        override_global_claim_validators=lambda global_claim_validators, __, ___: [
-            gcv for gcv in global_claim_validators if gcv.id == "st-mfa"
-        ],
+        override_global_claim_validators=lambda _, __, ___: [],
         session_required=True,
         user_context=user_context,
     )


### PR DESCRIPTION
## Summary of change

- Ensures that verified TOTP devices can only be removed after MFA requirements are completed
- Removes override for global claim validators

## Related issues

- https://github.com/supertokens/supertokens-node/commit/28a0f4adf4a9040e9ee0b3d2f3c571064b877625
- Updates handling introduced in #579 

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

