### PR TITLE
fix: reverts cookie timezones to GMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [unreleased]
-- Upgrades `pip` and `setuptools` in CI publish job
-- Also upgrades `poetry` and it's dependency - `clikit`
+
+## [0.28.2] - 2025-05-19
+- Fixes cookies being set without expiry in Django
+  - Reverts timezone change from 0.28.0 and uses GMT
 
 ## [0.28.1] - 2025-02-26
 - Pins `httpx` and `respx` to current major versions (<1.0.0)

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.28.1",
+    version="0.28.2",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.com",

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 SUPPORTED_CDI_VERSIONS = ["5.2"]
-VERSION = "0.28.1"
+VERSION = "0.28.2"
 TELEMETRY = "/telemetry"
 USER_COUNT = "/users/count"
 USER_DELETE = "/user/remove"

--- a/supertokens_python/framework/django/django_response.py
+++ b/supertokens_python/framework/django/django_response.py
@@ -51,7 +51,9 @@ class DjangoResponse(BaseResponse):
             key=key,
             value=value,
             expires=datetime.fromtimestamp(ceil(expires / 1000)).strftime(
-                "%a, %d %b %Y %H:%M:%S UTC"
+                # NOTE: This should always be GMT. HTTP only supports GMT in cookies.
+                # If this is not respected, the cookie is always treated as a session cookie.
+                "%a, %d %b %Y %H:%M:%S GMT"
             ),
             path=path,
             domain=domain,

--- a/tests/Django/test_django.py
+++ b/tests/Django/test_django.py
@@ -295,7 +295,7 @@ class SupertokensTest(TestCase):
 
         try:
             datetime.strptime(
-                cookies["sAccessToken"]["expires"], "%a, %d %b %Y %H:%M:%S UTC"
+                cookies["sAccessToken"]["expires"], "%a, %d %b %Y %H:%M:%S GMT"
             )
         except ValueError:
             assert False, "cookies expiry time doesn't have the correct format"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -663,13 +663,15 @@ async def test_token_cookie_expires(
     for c in response.cookies.jar:
         if c.name == "sAccessToken":  # 100 years (set by the SDK)
             # some time must have elasped since the cookie was set. So less than current time
-            assert datetime.fromtimestamp(c.expires or 0, tz=timezone.utc) - timedelta(
-                days=365.25 * 100
-            ) < datetime.now(tz=timezone.utc)
+            assert datetime.fromtimestamp(
+                c.expires or 0, tz=timezone(timedelta(0), "GMT")
+            ) - timedelta(days=365.25 * 100) < datetime.now(
+                tz=timezone(timedelta(0), "GMT")
+            )
         if c.name == "sRefreshToken":  # 100 days (set by the core)
-            assert datetime.fromtimestamp(c.expires or 0, tz=timezone.utc) - timedelta(
-                days=100
-            ) < datetime.now(tz=timezone.utc)
+            assert datetime.fromtimestamp(
+                c.expires or 0, tz=timezone(timedelta(0), "GMT")
+            ) - timedelta(days=100) < datetime.now(tz=timezone(timedelta(0), "GMT"))
 
     assert response.headers["anti-csrf"] != ""
     assert response.headers["front-token"] != ""
@@ -691,13 +693,15 @@ async def test_token_cookie_expires(
     for c in response.cookies.jar:
         if c.name == "sAccessToken":  # 100 years (set by the SDK)
             # some time must have elasped since the cookie was set. So less than current time
-            assert datetime.fromtimestamp(c.expires or 0, tz=timezone.utc) - timedelta(
-                days=365.25 * 100
-            ) < datetime.now(tz=timezone.utc)
+            assert datetime.fromtimestamp(
+                c.expires or 0, tz=timezone(timedelta(0), "GMT")
+            ) - timedelta(days=365.25 * 100) < datetime.now(
+                tz=timezone(timedelta(0), "GMT")
+            )
         if c.name == "sRefreshToken":  # 100 days (set by the core)
-            assert datetime.fromtimestamp(c.expires or 0, tz=timezone.utc) - timedelta(
-                days=100
-            ) < datetime.now(tz=timezone.utc)
+            assert datetime.fromtimestamp(
+                c.expires or 0, tz=timezone(timedelta(0), "GMT")
+            ) - timedelta(days=100) < datetime.now(tz=timezone(timedelta(0), "GMT"))
 
     assert response.headers["anti-csrf"] != ""
     assert response.headers["front-token"] != ""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ import json
 
 # Import AsyncMock
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from http.cookies import SimpleCookie
 from os import environ, kill, remove, scandir
 from pathlib import Path
@@ -320,7 +320,11 @@ def assert_info_clears_tokens(info: Dict[str, Any], token_transfer_method: str):
 
 
 def get_unix_timestamp(expiry: str):
-    return int(datetime.strptime(expiry, "%a, %d %b %Y %H:%M:%S UTC").timestamp())
+    return int(
+        datetime.strptime(expiry, "%a, %d %b %Y %H:%M:%S GMT")
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
+    )
 
 
 def verify_within_5_second_diff(n1: int, n2: int):


### PR DESCRIPTION
## Summary of change

- Fixes cookies being set without expiry in Django
  - Reverts timezone change from 0.28.0 and uses GMT

## Related issues

- #586
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Date#gmt

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

