### PR TITLE
fix: build-docs type error

### DIFF
--- a/supertokens_python/recipe/webauthn/emaildelivery/services/smtp/base.py
+++ b/supertokens_python/recipe/webauthn/emaildelivery/services/smtp/base.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Union
 
 from supertokens_python.ingredients.emaildelivery.services.smtp import Transporter
 from supertokens_python.ingredients.emaildelivery.types import (
@@ -33,11 +33,12 @@ class SMTPService(EmailDeliveryInterface[TypeWebauthnEmailDeliveryInput]):
     def __init__(
         self,
         smtp_settings: SMTPSettings,
-        override: Optional[
+        override: Union[
             Callable[
                 [SMTPServiceInterface[TypeWebauthnEmailDeliveryInput]],
                 SMTPServiceInterface[TypeWebauthnEmailDeliveryInput],
             ],
+            None,
         ] = None,
     ) -> None:
         transporter = Transporter(smtp_settings)


### PR DESCRIPTION
## Summary of change

- `pdoc3` prefers `Union` instead of `Optional` for `Callable`s

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
