### PR TITLE
fix: use core without dev mode, skip some tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,11 +2,11 @@ services:
   core:
     # Uses `$SUPERTOKENS_CORE_VERSION` when available, else latest
     image: supertokens/supertokens-dev-postgresql:${SUPERTOKENS_CORE_VERSION:-master}
-    entrypoint: [
-      "/usr/lib/supertokens/jre/bin/java",
-      "-classpath", "/usr/lib/supertokens/core/*:/usr/lib/supertokens/plugin-interface/*:/usr/lib/supertokens/ee/*",
-      "io.supertokens.Main", "/usr/lib/supertokens/", "DEV", "test_mode"
-    ]
+    # entrypoint: [
+    #   "/usr/lib/supertokens/jre/bin/java",
+    #   "-classpath", "/usr/lib/supertokens/core/*:/usr/lib/supertokens/plugin-interface/*:/usr/lib/supertokens/ee/*",
+    #   "io.supertokens.Main", "/usr/lib/supertokens/", "DEV", "test_mode"
+    # ]
     ports:
       # Uses `$SUPERTOKENS_CORE_PORT` when available, else 3567 for local port
       - ${SUPERTOKENS_CORE_PORT:-3567}:3567

--- a/tests/sessions/test_jwks.py
+++ b/tests/sessions/test_jwks.py
@@ -105,6 +105,7 @@ async def test_that_jwks_is_fetched_as_expected(caplog: LogCaptureFixture):
     JWKSConfig.update(original_jwks_config)
 
 
+@pytest.mark.skip("Requires core running in DEV + test_mode")
 async def test_that_jwks_result_is_refreshed_properly(caplog: LogCaptureFixture):
     """This test verifies that the cache used to store the pointer to the JWKS result is updated properly when the
     cache expired and the keys need to be refetched.
@@ -160,6 +161,7 @@ async def test_that_jwks_result_is_refreshed_properly(caplog: LogCaptureFixture)
     JWKSConfig.update(original_jwks_config)
 
 
+@pytest.mark.skip("Requires core running in DEV + test_mode")
 async def test_that_jwks_are_refresh_if_kid_is_unknown(caplog: LogCaptureFixture):
     """This test verifies that the SDK tried to re-fetch the keys from the core if the KID for the access token
     does not exist in the cache
@@ -605,6 +607,7 @@ async def test_session_verification_of_jwt_with_dynamic_signing_key():
     assert s_.get_user_id() == "userId"
 
 
+@pytest.mark.skip("Requires core running in DEV + test_mode")
 async def test_that_locking_for_jwks_cache_works(caplog: LogCaptureFixture):
     caplog.set_level(logging.DEBUG)
     not_returned_from_cache_count = get_log_occurence_count(


### PR DESCRIPTION
- Skips tests that use core config values below expected limits

## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
