### PR TITLE
chore: lift phonenumbers<9 upper bound to allow 9.x

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -44,7 +44,7 @@ RUN pip install --no-cache-dir \
     "asgiref>=3.4.1,<4" \
     "httpx>=0.15.0,<1.0.0" \
     "packaging>=25.0,<26.0" \
-    "phonenumbers<9" \
+    "phonenumbers>=8.0,<10" \
     "pkce<1.1.0" \
     "pycryptodome<3.21.0" \
     "pydantic>=2.10.6,<3.0.0" \

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         "asgiref>=3.4.1,<4",
         "httpx>=0.15.0,<1.0.0",
         "packaging>=25.0,<26.0",
-        "phonenumbers<9",
+        "phonenumbers>=8.0,<10",
         "pkce<1.1.0",
         "pycryptodome<3.21.0",
         "pydantic>=2.10.6,<3.0.0",


### PR DESCRIPTION
## Summary

The `phonenumbers<9` constraint in `setup.py` (and `Dockerfile.mcp`) prevents downstream users from receiving updated phone number metadata. This PR widens it to `phonenumbers>=8.0,<10`.

**Motivation:** US area code 324 (Jacksonville, FL — overlay of 904) went active in 2024. Support for this area code is only available in `phonenumbers` 9.x. The `<9` cap means any application using `supertokens-python` cannot parse or validate phone numbers with this area code (and any other metadata updates shipped in 9.x).

**Risk assessment:** The SDK uses only stable public APIs from the `phonenumbers` library:
- `phonenumbers.parse()`
- `phonenumbers.format_number()`
- `phonenumbers.is_valid_number()`
- `phonenumbers.PhoneNumberFormat.E164`

All of these are unchanged in the 8.x → 9.x transition. The `phonenumbers` 9.x release was a metadata-only major version bump (updated to libphonenumber v8.13.x upstream data); there were no breaking Python API changes.

## Changes

- `setup.py`: `"phonenumbers<9"` → `"phonenumbers>=8.0,<10"`
- `Dockerfile.mcp`: same change