### PR TITLE
fix(oauth2provider): error type system, JWKS, cookies, surface cleanup + pip cache

### DIFF
--- a/.changes/unreleased/Breaking Changes-20260506-144658.yaml
+++ b/.changes/unreleased/Breaking Changes-20260506-144658.yaml
@@ -1,0 +1,3 @@
+kind: Breaking Changes
+body: 'oauth2provider: introspect_token, validate_oauth2_refresh_token, accept_login_request, reject_login_request, accept_consent_request, and reject_consent_request now return an ErrorOAuth2Response variant when the SuperTokens core responds with status=OAUTH_ERROR (matches Node SDK). Previously the introspect path silently treated core errors as ''token inactive'' and the accept/reject paths raised KeyError on the missing redirectTo. Custom RecipeInterface overrides on these methods need to widen their return types to include ErrorOAuth2Response.'
+time: 2026-05-06T14:46:58.930996+02:00

--- a/.changes/unreleased/Fixed-20260506-145205.yaml
+++ b/.changes/unreleased/Fixed-20260506-145205.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'oauth2provider: validate_oauth2_access_token now uses the algorithm declared in the matching JWK (falling back to RS256) instead of always passing algorithms=[''RS256''] to pyjwt; raises a clear error when no JWK matches the token''s kid instead of falling through to a misleading ''Wrong token type''; and OAuth2ProviderRecipe.reset() drops the session JWKS cache so test runs against a different core don''t reuse stale keys (matches Node''s resetCombinedJWKS).'
+time: 2026-05-06T14:52:05.314701+02:00

--- a/.changes/unreleased/Fixed-20260506-145205.yaml
+++ b/.changes/unreleased/Fixed-20260506-145205.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: 'oauth2provider: validate_oauth2_access_token now uses the algorithm declared in the matching JWK (falling back to RS256) instead of always passing algorithms=[''RS256''] to pyjwt; raises a clear error when no JWK matches the token''s kid instead of falling through to a misleading ''Wrong token type''; and OAuth2ProviderRecipe.reset() drops the session JWKS cache so test runs against a different core don''t reuse stale keys (matches Node''s resetCombinedJWKS).'
+body: 'oauth2provider: validate_oauth2_access_token now uses the algorithm declared in the matching JWK (falling back to RS256) instead of always passing algorithms=[''RS256''] to pyjwt; raises a clear error when no JWK matches the token''s kid instead of falling through to a misleading ''Wrong token type''.'
 time: 2026-05-06T14:52:05.314701+02:00

--- a/.changes/unreleased/Fixed-20260506-150441.yaml
+++ b/.changes/unreleased/Fixed-20260506-150441.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'oauth2provider: cookie handling on the OAuth login/auth redirect chain. Cookies set by the core without an Expires attribute (or with an unparseable one) no longer crash api/auth.py and api/login.py with dateutil ValueError; they fall back to a 1-hour TTL via the new parse_expires_ms_or_default helper. get_merged_cookies now parses Set-Cookie attributes via SimpleCookie and drops cookies whose Expires is in the past (the core''s idiom for ''delete this cookie''), matching Node''s setCookieParser behavior; the previous implementation retained logout cookies in the merged result.'
+time: 2026-05-06T15:04:41.992921+02:00

--- a/.changes/unreleased/Fixed-20260506-151115.yaml
+++ b/.changes/unreleased/Fixed-20260506-151115.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'oauth2provider: minor public-surface consistency fixes. get_default_user_info_payload now omits phoneNumber from the payload when the user has no phone number (matches the access-token and id-token builders, and Node''s omit-on-undefined serialization). syncio.create_token_for_client_credentials now accepts client_secret as Optional[str] with a None default, matching the asyncio wrapper.'
+time: 2026-05-06T15:11:15.391273+02:00

--- a/.changes/unreleased/Infrastructure-20260506-151833.yaml
+++ b/.changes/unreleased/Infrastructure-20260506-151833.yaml
@@ -1,0 +1,3 @@
+kind: Infrastructure
+body: 'ci: enable pip download caching on actions/setup-python in unit-test, website-test, auth-react-test-3, and backend-sdk-testing workflows. Cuts the ''Create virtual environment and install dependencies'' step from ~30-90s to a few seconds when the dev-requirements.txt + setup.py hash matches a previous run. Also adds the missing setup-python step to backend-sdk-testing, which previously relied on whatever Python the runner shipped (the matrix declared py-version 3.8-3.13 but it was never honored).'
+time: 2026-05-06T15:18:33.928542+02:00

--- a/.changes/unreleased/Infrastructure-20260506-161626.yaml
+++ b/.changes/unreleased/Infrastructure-20260506-161626.yaml
@@ -1,0 +1,3 @@
+kind: Infrastructure
+body: 'compose: add weak Argon2 password-hashing config to the local core for tests. Default bcrypt is ~250ms/hash; the test surface (emailpassword, passwordless across unit, e2e auth-react and website matrices) does hundreds of sign-up/sign-in cycles. Argon2 with iterations=1, memory=8KB cuts each hash to ~1ms, projecting roughly 10 wall-clock minutes off the auth-react matrix. NOT for production.'
+time: 2026-05-06T16:16:26.287341+02:00

--- a/.changes/unreleased/Infrastructure-20260506-164629.yaml
+++ b/.changes/unreleased/Infrastructure-20260506-164629.yaml
@@ -1,0 +1,3 @@
+kind: Infrastructure
+body: 'tests: add opt-in timing middleware for test servers (LOG_TEST_TIMINGS=1). When enabled, monkey-patches the SuperTokens Querier to log per-call timing on outbound core requests ([QUERIER] METHOD path Xms) and adds a framework-specific HTTP middleware (FastAPI/Flask/Django) that logs timing on inbound test-server requests ([REQUEST] METHOD path STATUS Xms). Stdout is already captured to AUTH_REACT__LOG_DIR/<framework>.log in CI, so artifacts contain the data. Off by default; flip on by setting the env var on the workflow''s server-startup step.'
+time: 2026-05-06T16:46:29.214214+02:00

--- a/.github/workflows/auth-react-test-3.yml
+++ b/.github/workflows/auth-react-test-3.yml
@@ -130,6 +130,14 @@ jobs:
       - name: Start Server (fastapi)
         if: matrix.framework == 'fastapi'
         working-directory: supertokens-python
+        env:
+          # Capture timing for inbound test-server requests and outbound
+          # Querier calls to the core. Logs go to fastapi.log inside
+          # AUTH_REACT__LOG_DIR, which the auth-react-testing-action
+          # uploads as a workflow artifact. Grep for `[QUERIER]` and
+          # `[REQUEST]` to surface the slowest calls. Off in other
+          # frameworks/workflows; toggle here when you want data.
+          LOG_TEST_TIMINGS: '1'
         run: |
           source venv/bin/activate
           export PYTHONPATH="${PYTHONPATH}:$(pwd)"

--- a/.github/workflows/auth-react-test-3.yml
+++ b/.github/workflows/auth-react-test-3.yml
@@ -73,6 +73,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            supertokens-python/dev-requirements.txt
+            supertokens-python/setup.py
 
       - name: Create virtual environment and install dependencies
         working-directory: supertokens-python

--- a/.github/workflows/auth-react-test-3.yml
+++ b/.github/workflows/auth-react-test-3.yml
@@ -165,3 +165,17 @@ jobs:
           check-name-suffix: '[FDI=${{ inputs.fdi-version }}][Py=${{ matrix.py-version }}][Framework=${{ matrix.framework }}][Spec=${{ matrix.spec }}]'
           path: supertokens-auth-react
           spec: ${{ matrix.spec }}
+
+      # The auth-react-testing-action only uploads test_report/ on failure.
+      # We need the fastapi server's stdout (contains [QUERIER]/[REQUEST]
+      # lines from LOG_TEST_TIMINGS) regardless of pass/fail, so explicitly
+      # upload it here. fastapi-only since LOG_TEST_TIMINGS is only set on
+      # that framework's Start Server step.
+      - if: always() && matrix.framework == 'fastapi'
+        name: Upload test-server timing logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: timing-FDI${{ inputs.fdi-version }}-${{ strategy.job-index }}
+          path: ${{ env.AUTH_REACT__LOG_DIR }}/fastapi.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/backend-sdk-testing.yml
+++ b/.github/workflows/backend-sdk-testing.yml
@@ -117,6 +117,14 @@ jobs:
 
           echo "coreVersion=${coreVersion}" >> $GITHUB_OUTPUT
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            supertokens-python/dev-requirements.txt
+            supertokens-python/setup.py
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -118,6 +118,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            dev-requirements.txt
+            setup.py
 
       - name: Create virtual environment and install dependencies
         # Updrade `pip` and `setuptools` to have the latest versions before further installs

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -87,6 +87,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            supertokens-python/dev-requirements.txt
+            supertokens-python/setup.py
 
       - name: Get versions from current FDI/CDI version
         id: versions

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,15 @@ services:
       INFO_LOG_PATH: "null"
       ERROR_LOG_PATH: "null"
       LOG_LEVEL: "DEBUG"
+      # Test-only: dial password hashing down to milliseconds. The default
+      # bcrypt settings are ~250ms/hash, which adds up across the
+      # emailpassword/passwordless test surface. Argon2 with these
+      # deliberately weak parameters runs in ~1ms. NOT FOR PRODUCTION.
+      PASSWORD_HASHING_ALG: ARGON2
+      ARGON2_ITERATIONS: 1
+      ARGON2_MEMORY_KB: 8
+      ARGON2_PARALLELISM: 1
+      ARGON2_HASHING_POOL_SIZE: 8
     healthcheck:
       test: bash -c 'curl -s "http://127.0.0.1:3567/hello" | grep "Hello"'
       interval: 10s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.ruff]
 line-length = 88 # Match Black's formatting
 src = ["supertokens_python"]
+# Match setup.py's python_requires=">=3.8" so ruff-format doesn't emit
+# 3.9+ syntax (e.g. parenthesized `with` statements).
+target-version = "py38"
 
 [tool.ruff.lint]
 extend-select = [

--- a/supertokens_python/recipe/oauth2provider/api/auth.py
+++ b/supertokens_python/recipe/oauth2provider/api/auth.py
@@ -18,8 +18,6 @@ from http.cookies import SimpleCookie
 from typing import TYPE_CHECKING, Any, Dict
 from urllib.parse import parse_qsl
 
-from dateutil import parser
-
 from supertokens_python.utils import send_200_response, send_non_200_response
 
 if TYPE_CHECKING:
@@ -28,7 +26,7 @@ if TYPE_CHECKING:
         APIOptions,
     )
 
-from .utils import get_session
+from .utils import get_session, parse_expires_ms_or_default
 
 
 async def auth_get(
@@ -88,8 +86,9 @@ async def auth_get(
                         domain=morsel.get("domain"),
                         secure=morsel.get("secure", True),
                         httponly=morsel.get("httponly", True),
-                        expires=parser.parse(morsel.get("expires", "")).timestamp()
-                        * 1000,  # type: ignore
+                        expires=parse_expires_ms_or_default(
+                            str(morsel.get("expires", ""))
+                        ),
                         path=morsel.get("path", "/"),
                         samesite=morsel.get("samesite", "lax"),
                     )

--- a/supertokens_python/recipe/oauth2provider/api/implementation.py
+++ b/supertokens_python/recipe/oauth2provider/api/implementation.py
@@ -204,7 +204,12 @@ class APIImplementation(APIInterface):
         scopes: Optional[List[str]],
         options: APIOptions,
         user_context: Dict[str, Any],
-    ) -> Union[ActiveTokenResponse, InactiveTokenResponse, GeneralErrorResponse]:
+    ) -> Union[
+        ActiveTokenResponse,
+        InactiveTokenResponse,
+        ErrorOAuth2Response,
+        GeneralErrorResponse,
+    ]:
         return await options.recipe_implementation.introspect_token(
             token=token,
             scopes=scopes,

--- a/supertokens_python/recipe/oauth2provider/api/login.py
+++ b/supertokens_python/recipe/oauth2provider/api/login.py
@@ -17,13 +17,11 @@ from __future__ import annotations
 from http.cookies import SimpleCookie
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from dateutil import parser
-
 from supertokens_python.exceptions import raise_bad_input_exception
 from supertokens_python.framework import BaseResponse
 from supertokens_python.utils import send_200_response, send_non_200_response
 
-from .utils import get_session
+from .utils import get_session, parse_expires_ms_or_default
 
 if TYPE_CHECKING:
     from ..interfaces import (
@@ -89,8 +87,9 @@ async def login(
                         domain=morsel.get("domain"),
                         secure=morsel.get("secure", True),
                         httponly=morsel.get("httponly", True),
-                        expires=parser.parse(morsel.get("expires", "")).timestamp()
-                        * 1000,  # type: ignore
+                        expires=parse_expires_ms_or_default(
+                            str(morsel.get("expires", ""))
+                        ),
                         path=morsel.get("path", "/"),
                         samesite=morsel.get("samesite", "lax").lower(),
                     )

--- a/supertokens_python/recipe/oauth2provider/api/utils.py
+++ b/supertokens_python/recipe/oauth2provider/api/utils.py
@@ -94,6 +94,8 @@ async def login_get(
                     ),
                     user_context=user_context,
                 )
+                if isinstance(reject, ErrorOAuth2Response):
+                    return reject
                 return RedirectResponse(
                     redirect_to=reject.redirect_to,
                     cookies=cookies,
@@ -108,6 +110,8 @@ async def login_get(
                 ),
                 user_context=user_context,
             )
+            if isinstance(reject, ErrorOAuth2Response):
+                return reject
             return RedirectResponse(
                 redirect_to=reject.redirect_to,
                 cookies=cookies,
@@ -140,6 +144,8 @@ async def login_get(
             identity_provider_session_id=session.get_handle(),
             user_context=user_context,
         )
+        if isinstance(accept, ErrorOAuth2Response):
+            return accept
         return RedirectResponse(
             redirect_to=accept.redirect_to,
             cookies=cookies,
@@ -165,6 +171,8 @@ async def login_get(
             ),
             user_context=user_context,
         )
+        if isinstance(reject, ErrorOAuth2Response):
+            return reject
         return RedirectResponse(
             redirect_to=reject.redirect_to,
             cookies=cookies,

--- a/supertokens_python/recipe/oauth2provider/api/utils.py
+++ b/supertokens_python/recipe/oauth2provider/api/utils.py
@@ -16,8 +16,12 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime, timezone
+from http.cookies import SimpleCookie
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 from urllib.parse import parse_qs, urlparse
+
+from dateutil import parser
 
 from supertokens_python.recipe.multitenancy.constants import DEFAULT_TENANT_ID
 from supertokens_python.recipe.session.interfaces import SessionClaimValidator
@@ -206,16 +210,59 @@ def get_merged_cookies(orig_cookies: str, new_cookies: Optional[List[str]]) -> s
             name, value = cookie.split("=", 1)
             cookie_map[name.strip()] = value
 
-    # Note: This is a simplified version. In production code you'd want to use a proper
-    # cookie parsing library to handle all cookie attributes correctly
-    if new_cookies:
-        for cookie_str in new_cookies:
-            cookie = cookie_str.split(";")[0].strip()
-            if "=" in cookie:
-                name, value = cookie.split("=", 1)
+    now = datetime.now(timezone.utc)
+    for cookie_str in new_cookies:
+        try:
+            parsed = SimpleCookie()
+            parsed.load(cookie_str)
+        except Exception:
+            # Fall back to the legacy "first segment is name=value" behavior
+            # if SimpleCookie chokes on the input.
+            head = cookie_str.split(";")[0].strip()
+            if "=" in head:
+                name, value = head.split("=", 1)
                 cookie_map[name.strip()] = value
+            continue
+
+        for morsel in parsed.values():
+            expires_at = _parse_cookie_expires(morsel.get("expires", ""))
+            if expires_at is not None and expires_at < now:
+                # Cookie has been instructed to expire — the core is asking
+                # us to drop it. Match Node's setCookieParser-based behavior.
+                cookie_map.pop(morsel.key, None)
+                continue
+            cookie_map[morsel.key] = morsel.value
 
     return ";".join(f"{key}={value}" for key, value in cookie_map.items())
+
+
+def _parse_cookie_expires(expires_str: str) -> Optional[datetime]:
+    if not expires_str:
+        return None
+    try:
+        parsed = parser.parse(expires_str)
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def parse_expires_ms_or_default(expires_str: str) -> int:
+    """Convert a Set-Cookie `Expires` attribute to ms since epoch.
+
+    The framework abstract `set_cookie(..., expires: int, ...)` requires an
+    integer, so we can't represent "session cookie" cleanly. When the input
+    is missing or unparseable (e.g. the core sent a cookie with no Expires —
+    a session cookie), fall back to "now + 1 hour" so the cookie survives
+    the OAuth internal redirect chain without persisting indefinitely.
+    Previously this called `dateutil.parser.parse("")` which raises ValueError
+    and crashed the auth/login handlers.
+    """
+    parsed = _parse_cookie_expires(expires_str)
+    if parsed is None:
+        return int((time.time() + 3600) * 1000)
+    return int(parsed.timestamp() * 1000)
 
 
 def merge_set_cookie_headers(

--- a/supertokens_python/recipe/oauth2provider/asyncio/__init__.py
+++ b/supertokens_python/recipe/oauth2provider/asyncio/__init__.py
@@ -238,7 +238,7 @@ async def validate_oauth2_refresh_token(
     token: str,
     scopes: Optional[List[str]] = None,
     user_context: Optional[Dict[str, Any]] = None,
-) -> Union[ActiveTokenResponse, InactiveTokenResponse]:
+) -> Union[ActiveTokenResponse, InactiveTokenResponse, ErrorOAuth2Response]:
     if user_context is None:
         user_context = {}
     from ..recipe import OAuth2ProviderRecipe

--- a/supertokens_python/recipe/oauth2provider/interfaces.py
+++ b/supertokens_python/recipe/oauth2provider/interfaces.py
@@ -1057,13 +1057,13 @@ class RecipeInterface(BaseRecipeInterface):
         initial_access_token_payload: Optional[Dict[str, Any]],
         initial_id_token_payload: Optional[Dict[str, Any]],
         user_context: Dict[str, Any],
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         pass
 
     @abstractmethod
     async def reject_consent_request(
         self, challenge: str, error: ErrorOAuth2Response, user_context: Dict[str, Any]
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         pass
 
     @abstractmethod
@@ -1083,7 +1083,7 @@ class RecipeInterface(BaseRecipeInterface):
         identity_provider_session_id: Optional[str],
         subject: str,
         user_context: Dict[str, Any],
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         pass
 
     @abstractmethod
@@ -1092,7 +1092,7 @@ class RecipeInterface(BaseRecipeInterface):
         challenge: str,
         error: ErrorOAuth2Response,
         user_context: Dict[str, Any],
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         pass
 
     @abstractmethod
@@ -1237,7 +1237,7 @@ class RecipeInterface(BaseRecipeInterface):
         token: str,
         scopes: Optional[List[str]],
         user_context: Dict[str, Any],
-    ) -> Union[ActiveTokenResponse, InactiveTokenResponse]:
+    ) -> Union[ActiveTokenResponse, InactiveTokenResponse, ErrorOAuth2Response]:
         pass
 
     @abstractmethod
@@ -1375,7 +1375,12 @@ class APIInterface(BaseAPIInterface):
         scopes: Optional[List[str]],
         options: APIOptions,
         user_context: Dict[str, Any],
-    ) -> Union[ActiveTokenResponse, InactiveTokenResponse, GeneralErrorResponse]:
+    ) -> Union[
+        ActiveTokenResponse,
+        InactiveTokenResponse,
+        ErrorOAuth2Response,
+        GeneralErrorResponse,
+    ]:
         pass
 
     @abstractmethod

--- a/supertokens_python/recipe/oauth2provider/recipe.py
+++ b/supertokens_python/recipe/oauth2provider/recipe.py
@@ -306,6 +306,14 @@ class OAuth2ProviderRecipe(RecipeModule):
             environ["SUPERTOKENS_ENV"] != "testing"
         ):
             raise_general_exception("calling testing function in non testing env")
+        # Drop the session recipe's cached JWKS too. The OAuth2 provider's
+        # access-token validation reads keys from the session JWKS cache, so
+        # without this a fresh recipe instance would reuse keys from a
+        # previously-pointed-at core in long-running test suites (matches
+        # Node's resetCombinedJWKS).
+        from supertokens_python.recipe.session.jwks import reset_jwks_cache
+
+        reset_jwks_cache()
         OAuth2ProviderRecipe.__instance = None
 
     def add_user_info_builder_from_other_recipe(

--- a/supertokens_python/recipe/oauth2provider/recipe.py
+++ b/supertokens_python/recipe/oauth2provider/recipe.py
@@ -434,9 +434,8 @@ class OAuth2ProviderRecipe(RecipeModule):
             payload["emails"] = user.emails
 
         if "phoneNumber" in scopes:
-            payload["phoneNumber"] = (
-                user.phone_numbers[0] if user.phone_numbers else None
-            )
+            if user.phone_numbers:
+                payload["phoneNumber"] = user.phone_numbers[0]
             payload["phoneNumber_verified"] = (
                 any(
                     lm.has_same_phone_number_as(user.phone_numbers[0]) and lm.verified

--- a/supertokens_python/recipe/oauth2provider/recipe.py
+++ b/supertokens_python/recipe/oauth2provider/recipe.py
@@ -306,14 +306,14 @@ class OAuth2ProviderRecipe(RecipeModule):
             environ["SUPERTOKENS_ENV"] != "testing"
         ):
             raise_general_exception("calling testing function in non testing env")
-        # Drop the session recipe's cached JWKS too. The OAuth2 provider's
-        # access-token validation reads keys from the session JWKS cache, so
-        # without this a fresh recipe instance would reuse keys from a
-        # previously-pointed-at core in long-running test suites (matches
-        # Node's resetCombinedJWKS).
-        from supertokens_python.recipe.session.jwks import reset_jwks_cache
-
-        reset_jwks_cache()
+        # Note: unlike Node's resetCombinedJWKS, we deliberately do NOT
+        # clear the session recipe's JWKS cache here. Python's session and
+        # OAuth2 provider recipes share a single module-level JWKS cache,
+        # and existing session tests (e.g.
+        # test_session_verification_of_jwt_with_dynamic_signing_key_mode_works_as_expected)
+        # rely on the cache persisting across reset() to test "old token,
+        # new config" semantics. Tests that genuinely need a fresh JWKS
+        # cache should call reset_jwks_cache() directly.
         OAuth2ProviderRecipe.__instance = None
 
     def add_user_info_builder_from_other_recipe(

--- a/supertokens_python/recipe/oauth2provider/recipe_implementation.py
+++ b/supertokens_python/recipe/oauth2provider/recipe_implementation.py
@@ -684,8 +684,16 @@ class RecipeImplementation(RecipeInterface):
         # Verify token signature using session recipe's JWKS
         session_recipe = SessionRecipe.get_instance()
         matching_keys = get_latest_keys(session_recipe.config, access_token_obj.kid)
-        err: Optional[Exception] = None
 
+        if not matching_keys:
+            # The JWS header advertised a kid that none of the JWKs we know
+            # about match. Surface this as a signature/key error rather than
+            # falling through to a misleading "Wrong token type".
+            raise Exception(
+                f"No JWKS key matching kid={access_token_obj.kid!r}; cannot verify access-token signature"
+            )
+
+        err: Optional[Exception] = None
         payload: Dict[str, Any] = {}
 
         for matching_key in matching_keys:
@@ -694,7 +702,7 @@ class RecipeImplementation(RecipeInterface):
                 payload = jwt.decode(
                     token,
                     matching_key.key,
-                    algorithms=["RS256"],
+                    algorithms=[matching_key.algorithm_name or "RS256"],
                     options={
                         "verify_signature": True,
                         "verify_exp": True,

--- a/supertokens_python/recipe/oauth2provider/recipe_implementation.py
+++ b/supertokens_python/recipe/oauth2provider/recipe_implementation.py
@@ -117,7 +117,7 @@ class RecipeImplementation(RecipeInterface):
         identity_provider_session_id: Optional[str],
         subject: str,
         user_context: Dict[str, Any],
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         response = await self.querier.send_put_request(
             NormalisedURLPath("/recipe/oauth/auth/requests/login/accept"),
             {
@@ -134,6 +134,13 @@ class RecipeImplementation(RecipeInterface):
             user_context=user_context,
         )
 
+        if response.get("status") == "OAUTH_ERROR":
+            return ErrorOAuth2Response(
+                error=str(response.get("error")),
+                error_description=str(response.get("errorDescription")),
+                status_code=response.get("statusCode"),
+            )
+
         return RedirectResponse(
             redirect_to=get_updated_redirect_to(self.app_info, response["redirectTo"])
         )
@@ -143,7 +150,7 @@ class RecipeImplementation(RecipeInterface):
         challenge: str,
         error: ErrorOAuth2Response,
         user_context: Dict[str, Any],
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         response = await self.querier.send_put_request(
             NormalisedURLPath("/recipe/oauth/auth/requests/login/reject"),
             {
@@ -156,6 +163,14 @@ class RecipeImplementation(RecipeInterface):
             },
             user_context=user_context,
         )
+
+        if response.get("status") == "OAUTH_ERROR":
+            return ErrorOAuth2Response(
+                error=str(response.get("error")),
+                error_description=str(response.get("errorDescription")),
+                status_code=response.get("statusCode"),
+            )
+
         return RedirectResponse(
             redirect_to=get_updated_redirect_to(self.app_info, response["redirectTo"])
         )
@@ -184,7 +199,7 @@ class RecipeImplementation(RecipeInterface):
         initial_access_token_payload: Optional[Dict[str, Any]],
         initial_id_token_payload: Optional[Dict[str, Any]],
         user_context: Dict[str, Any],
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         response = await self.querier.send_put_request(
             NormalisedURLPath("/recipe/oauth/auth/requests/consent/accept"),
             {
@@ -205,13 +220,20 @@ class RecipeImplementation(RecipeInterface):
             user_context=user_context,
         )
 
+        if response.get("status") == "OAUTH_ERROR":
+            return ErrorOAuth2Response(
+                error=str(response.get("error")),
+                error_description=str(response.get("errorDescription")),
+                status_code=response.get("statusCode"),
+            )
+
         return RedirectResponse(
             redirect_to=get_updated_redirect_to(self.app_info, response["redirectTo"])
         )
 
     async def reject_consent_request(
         self, challenge: str, error: ErrorOAuth2Response, user_context: Dict[str, Any]
-    ) -> RedirectResponse:
+    ) -> Union[RedirectResponse, ErrorOAuth2Response]:
         response = await self.querier.send_put_request(
             NormalisedURLPath("/recipe/oauth/auth/requests/consent/reject"),
             {
@@ -224,6 +246,13 @@ class RecipeImplementation(RecipeInterface):
             },
             user_context=user_context,
         )
+
+        if response.get("status") == "OAUTH_ERROR":
+            return ErrorOAuth2Response(
+                error=str(response.get("error")),
+                error_description=str(response.get("errorDescription")),
+                status_code=response.get("statusCode"),
+            )
 
         return RedirectResponse(
             redirect_to=get_updated_redirect_to(self.app_info, response["redirectTo"])
@@ -380,6 +409,9 @@ class RecipeImplementation(RecipeInterface):
                 user_context=user_context,
             )
 
+            if isinstance(consent_res, ErrorOAuth2Response):
+                return consent_res
+
             return RedirectResponse(
                 redirect_to=consent_res.redirect_to, cookies=resp["cookies"]
             )
@@ -458,6 +490,8 @@ class RecipeImplementation(RecipeInterface):
                 scopes=scopes,
                 user_context=user_context,
             )
+            if isinstance(token_info, ErrorOAuth2Response):
+                return token_info
             if isinstance(token_info, InactiveTokenResponse):
                 return ErrorOAuth2Response(
                     status_code=400,
@@ -872,7 +906,7 @@ class RecipeImplementation(RecipeInterface):
         token: str,
         scopes: Optional[List[str]],
         user_context: Dict[str, Any],
-    ) -> Union[ActiveTokenResponse, InactiveTokenResponse]:
+    ) -> Union[ActiveTokenResponse, InactiveTokenResponse, ErrorOAuth2Response]:
         # Determine if the token is an access token by checking if it doesn't start with "st_rt"
         is_access_token = not token.startswith("st_rt")
 
@@ -905,6 +939,13 @@ class RecipeImplementation(RecipeInterface):
             request_body,
             user_context=user_context,
         )
+
+        if res.get("status") == "OAUTH_ERROR":
+            return ErrorOAuth2Response(
+                error=str(res.get("error")),
+                error_description=str(res.get("errorDescription")),
+                status_code=res.get("statusCode"),
+            )
 
         if res.get("active"):
             return ActiveTokenResponse(payload=res)

--- a/supertokens_python/recipe/oauth2provider/syncio/__init__.py
+++ b/supertokens_python/recipe/oauth2provider/syncio/__init__.py
@@ -113,7 +113,7 @@ def validate_oauth2_access_token(
 
 def create_token_for_client_credentials(
     client_id: str,
-    client_secret: str,
+    client_secret: Optional[str] = None,
     scope: Optional[List[str]] = None,
     audience: Optional[str] = None,
     user_context: Optional[Dict[str, Any]] = None,

--- a/supertokens_python/recipe/oauth2provider/syncio/__init__.py
+++ b/supertokens_python/recipe/oauth2provider/syncio/__init__.py
@@ -169,7 +169,7 @@ def validate_oauth2_refresh_token(
     token: str,
     scopes: Optional[List[str]] = None,
     user_context: Optional[Dict[str, Any]] = None,
-) -> Union[ActiveTokenResponse, InactiveTokenResponse]:
+) -> Union[ActiveTokenResponse, InactiveTokenResponse, ErrorOAuth2Response]:
     if user_context is None:
         user_context = {}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import nest_asyncio  # type: ignore
-
-nest_asyncio.apply()  # type: ignore
+# nest_asyncio is only required by the `flask-nest-asyncio` website-test
+# matrix variant (and the unit/auth-react/backend-sdk envs that install
+# dev-requirements.txt). The other website-test variants run `make with-X`
+# without dev-requirements.txt and don't have it installed, so importing
+# unconditionally breaks any later `from tests.<...> import ...` in those
+# test servers. Make the apply optional.
+try:
+    import nest_asyncio  # type: ignore
+except ImportError:
+    pass
+else:
+    nest_asyncio.apply()  # type: ignore

--- a/tests/_test_timing.py
+++ b/tests/_test_timing.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Test-only timing middleware for the e2e and integration test servers.
+
+Enabled by setting `LOG_TEST_TIMINGS=1` in the env before any test-server
+init code runs. Two streams are emitted to stdout, one line each:
+
+    [QUERIER] POST /recipe/oauth/auth 47.3ms          # outbound to core
+    [REQUEST] POST /auth/signin 200 121.4ms           # inbound to test server
+
+Test-server stdout is already captured to AUTH_REACT__LOG_DIR/<framework>.log
+(or the website-test equivalent), so after a CI run the artifact contains
+the timing data. Aggregate with grep + awk to find the slowest calls.
+
+This module deliberately doesn't change SDK behavior when disabled — the
+`install_*` helpers no-op unless the env var is set.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Callable
+
+
+def _enabled() -> bool:
+    return bool(os.environ.get("LOG_TEST_TIMINGS"))
+
+
+# ---------------------------------------------------------------------------
+# Outbound: SuperTokens Querier (test server -> core)
+# ---------------------------------------------------------------------------
+
+
+def install_querier_timing() -> None:
+    """Monkey-patch Querier's four HTTP entry points to log per-call timing.
+
+    Safe to call multiple times; only patches once.
+    """
+    if not _enabled():
+        return
+
+    from supertokens_python.querier import Querier
+
+    if getattr(Querier, "_timing_installed", False):
+        return
+
+    methods = [
+        ("send_post_request", "POST"),
+        ("send_get_request", "GET"),
+        ("send_put_request", "PUT"),
+        ("send_delete_request", "DELETE"),
+    ]
+
+    for attr, label in methods:
+        original = getattr(Querier, attr)
+        setattr(Querier, attr, _wrap_querier_method(original, label))
+
+    Querier._timing_installed = True  # type: ignore[attr-defined]
+
+
+def _wrap_querier_method(orig: Callable[..., Any], label: str) -> Callable[..., Any]:
+    async def wrapper(self: Any, path: Any, *args: Any, **kwargs: Any) -> Any:
+        start = time.perf_counter_ns()
+        try:
+            return await orig(self, path, *args, **kwargs)
+        finally:
+            elapsed_ms = (time.perf_counter_ns() - start) / 1e6
+            path_str = (
+                path.get_as_string_dangerous()
+                if hasattr(path, "get_as_string_dangerous")
+                else str(path)
+            )
+            print(
+                f"[QUERIER] {label} {path_str} {elapsed_ms:.1f}ms",
+                flush=True,
+            )
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Inbound: HTTP requests served by the test server (browser -> test server)
+# ---------------------------------------------------------------------------
+
+
+def install_fastapi_request_timing(app: Any) -> None:
+    """Add a FastAPI HTTP middleware that logs (method, path, status, ms)."""
+    if not _enabled():
+        return
+
+    @app.middleware("http")
+    async def _timing_middleware(  # pyright: ignore[reportUnusedFunction]
+        request: Any, call_next: Callable[..., Any]
+    ) -> Any:
+        start = time.perf_counter_ns()
+        response = await call_next(request)
+        elapsed_ms = (time.perf_counter_ns() - start) / 1e6
+        print(
+            f"[REQUEST] {request.method} {request.url.path} "
+            f"{response.status_code} {elapsed_ms:.1f}ms",
+            flush=True,
+        )
+        return response
+
+
+def install_flask_request_timing(app: Any) -> None:
+    """Add Flask before/after request hooks that log timing."""
+    if not _enabled():
+        return
+
+    from flask import g, request
+
+    @app.before_request
+    def _start_timer() -> None:  # pyright: ignore[reportUnusedFunction]
+        g._timing_start_ns = time.perf_counter_ns()
+
+    @app.after_request
+    def _log_timing(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        start_ns = getattr(g, "_timing_start_ns", time.perf_counter_ns())
+        elapsed_ms = (time.perf_counter_ns() - start_ns) / 1e6
+        print(
+            f"[REQUEST] {request.method} {request.path} "
+            f"{response.status_code} {elapsed_ms:.1f}ms",
+            flush=True,
+        )
+        return response
+
+
+def get_django_request_timing_middleware() -> Any:
+    """Return a Django middleware class. Add the dotted path to MIDDLEWARE.
+
+    Usage in settings.py:
+
+        MIDDLEWARE = [
+            ...,
+            'tests._test_timing.DjangoRequestTimingMiddleware',
+        ]
+    """
+    return DjangoRequestTimingMiddleware
+
+
+class DjangoRequestTimingMiddleware:
+    """Django request-timing middleware. No-op unless LOG_TEST_TIMINGS is set."""
+
+    def __init__(self, get_response: Callable[..., Any]):
+        self.get_response = get_response
+        self.enabled = _enabled()
+
+    def __call__(self, request: Any) -> Any:
+        if not self.enabled:
+            return self.get_response(request)
+
+        start = time.perf_counter_ns()
+        response = self.get_response(request)
+        elapsed_ms = (time.perf_counter_ns() - start) / 1e6
+        print(
+            f"[REQUEST] {request.method} {request.path} "
+            f"{response.status_code} {elapsed_ms:.1f}ms",
+            flush=True,
+        )
+        return response

--- a/tests/auth-react/fastapi-server/app.py
+++ b/tests/auth-react/fastapi-server/app.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import os
+import sys
 import time
 import typing
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypedDict, Union
@@ -191,8 +192,22 @@ from typing_extensions import Literal
 
 load_dotenv("../auth-react.env")
 
+# Optional timing instrumentation, gated by LOG_TEST_TIMINGS=1.
+# Path bootstrap so we can import tests._test_timing when run via uvicorn
+# from this directory.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+from tests._test_timing import (  # noqa: E402
+    install_fastapi_request_timing,
+    install_querier_timing,
+)
+
+install_querier_timing()
+
 app = FastAPI(debug=True)
 app.add_middleware(get_middleware())
+install_fastapi_request_timing(app)
 os.environ.setdefault("SUPERTOKENS_ENV", "testing")
 
 

--- a/tests/auth-react/flask-server/app.py
+++ b/tests/auth-react/flask-server/app.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import os
+import sys
 import time
 import traceback
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypedDict, Union
@@ -1206,7 +1207,19 @@ def make_default_options_response():
     return _response
 
 
+# Optional timing instrumentation, gated by LOG_TEST_TIMINGS=1.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+from tests._test_timing import (  # noqa: E402
+    install_flask_request_timing,
+    install_querier_timing,
+)
+
+install_querier_timing()
+
 app = Flask(__name__, template_folder="templates")
+install_flask_request_timing(app)
 app.make_default_options_response = make_default_options_response
 Middleware(app)
 CORS(

--- a/tests/frontendIntegration/fastapi-server/app.py
+++ b/tests/frontendIntegration/fastapi-server/app.py
@@ -76,8 +76,20 @@ protected_prop_name = {
 index_file = open("templates/index.html", "r")
 file_contents = index_file.read()
 index_file.close()
+# Optional timing instrumentation, gated by LOG_TEST_TIMINGS=1.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+from tests._test_timing import (  # noqa: E402
+    install_fastapi_request_timing,
+    install_querier_timing,
+)
+
+install_querier_timing()
+
 app = FastAPI(debug=True)
 app.add_middleware(get_middleware())
+install_fastapi_request_timing(app)
 os.environ.setdefault("SUPERTOKENS_ENV", "testing")
 
 last_set_enable_anti_csrf = True

--- a/tests/frontendIntegration/flask-server/app.py
+++ b/tests/frontendIntegration/flask-server/app.py
@@ -80,7 +80,19 @@ index_file = open("templates/index.html", "r")
 file_contents = index_file.read()
 index_file.close()
 
+# Optional timing instrumentation, gated by LOG_TEST_TIMINGS=1.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+from tests._test_timing import (  # noqa: E402
+    install_flask_request_timing,
+    install_querier_timing,
+)
+
+install_querier_timing()
+
 app = Flask(__name__, template_folder="templates")
+install_flask_request_timing(app)
 Middleware(app)
 CORS(app, supports_credentials=True)
 os.environ.setdefault("SUPERTOKENS_ENV", "testing")

--- a/tests/oauth2provider/test_cookie_handling.py
+++ b/tests/oauth2provider/test_cookie_handling.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Plan 4 regression tests:
+
+- N7: api/auth.py and api/login.py call set_cookie with `expires=...`
+  derived from the cookie's `Expires` attribute. When the attribute is
+  missing or unparseable, the previous code crashed with `ValueError`
+  because `dateutil.parser.parse("")` raises. The shared helper
+  `parse_expires_ms_or_default` now falls back to a 1-hour TTL.
+
+- N8: get_merged_cookies must drop cookies whose `Expires` is in the
+  past (the OAuth core's idiom for "delete this cookie") instead of
+  retaining the value, matching Node's setCookieParser behavior.
+"""
+
+import time
+
+from supertokens_python.recipe.oauth2provider.api.utils import (
+    get_merged_cookies,
+    parse_expires_ms_or_default,
+)
+
+
+def test_parse_expires_ms_or_default_with_empty_string_returns_fallback():
+    before = time.time()
+    result = parse_expires_ms_or_default("")
+    after = time.time()
+    # Result is in ms; should be roughly now + 1 hour.
+    assert before * 1000 + 3500 * 1000 < result < after * 1000 + 3700 * 1000
+
+
+def test_parse_expires_ms_or_default_with_unparseable_returns_fallback():
+    before = time.time()
+    result = parse_expires_ms_or_default("not-a-real-date")
+    after = time.time()
+    assert before * 1000 + 3500 * 1000 < result < after * 1000 + 3700 * 1000
+
+
+def test_parse_expires_ms_or_default_with_valid_date():
+    # A specific UTC date.
+    result = parse_expires_ms_or_default("Wed, 01 Jan 2025 00:00:00 GMT")
+    # 2025-01-01 00:00:00 UTC == 1735689600 seconds since epoch.
+    assert result == 1735689600 * 1000
+
+
+def test_get_merged_cookies_keeps_cookie_with_no_expires_attribute():
+    """A cookie without an Expires attribute should be retained — it's a
+    session cookie, not a 'delete this cookie' instruction."""
+    merged = get_merged_cookies(
+        orig_cookies="other_cookie=other_value",
+        new_cookies=["hydra_login_csrf=token-value; Path=/"],
+    )
+
+    assert "hydra_login_csrf=token-value" in merged
+    assert "other_cookie=other_value" in merged
+
+
+def test_get_merged_cookies_drops_cookie_when_expires_is_in_past():
+    """The OAuth core signals 'delete this cookie' by setting Expires in the
+    past. get_merged_cookies must honor that and remove the cookie from the
+    map, so the redirect chain reflects the core's intent.
+
+    Previously Python only looked at the first `name=value` segment and
+    ignored attributes entirely, so logout cookies survived the merge.
+    """
+    merged = get_merged_cookies(
+        orig_cookies="hydra_login_csrf=existing-value; other=keep",
+        new_cookies=[
+            "hydra_login_csrf=ignored; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+        ],
+    )
+
+    assert "hydra_login_csrf=" not in merged
+    assert "other=keep" in merged
+
+
+def test_get_merged_cookies_overwrites_when_expires_is_in_future():
+    merged = get_merged_cookies(
+        orig_cookies="hydra_login_csrf=old-value",
+        new_cookies=[
+            "hydra_login_csrf=new-value; Path=/; Expires=Wed, 01 Jan 2099 00:00:00 GMT"
+        ],
+    )
+
+    assert "hydra_login_csrf=new-value" in merged
+    assert "hydra_login_csrf=old-value" not in merged
+
+
+def test_get_merged_cookies_with_no_new_cookies_is_passthrough():
+    assert get_merged_cookies("a=1; b=2", None) == "a=1; b=2"
+    assert get_merged_cookies("a=1; b=2", []) == "a=1; b=2"

--- a/tests/oauth2provider/test_jwks_validation.py
+++ b/tests/oauth2provider/test_jwks_validation.py
@@ -58,15 +58,13 @@ async def test_validate_access_token_raises_clear_error_when_no_matching_key():
     fake_token_obj = MagicMock()
     fake_token_obj.kid = "missing-kid"
 
-    with (
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
-            return_value=fake_token_obj,
-        ),
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
-            return_value=[],
-        ),
+    # Avoid PEP 617 parenthesized-`with` syntax — Python 3.8 doesn't support it.
+    with patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
+        return_value=fake_token_obj,
+    ), patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
+        return_value=[],
     ):
         with raises(Exception, match="No JWKS key matching kid"):
             await OAuth2ProviderRecipe.get_instance().recipe_implementation.validate_oauth2_access_token(
@@ -100,19 +98,16 @@ async def test_validate_access_token_uses_algorithm_from_jwk():
         captured_algorithms.append(algorithms)
         return {"stt": 1, "tId": "public", "sessionHandle": "handle-1"}
 
-    with (
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
-            return_value=fake_token_obj,
-        ),
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
-            return_value=[fake_key],
-        ),
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.jwt.decode",
-            side_effect=fake_decode,
-        ),
+    # Avoid PEP 617 parenthesized-`with` syntax — Python 3.8 doesn't support it.
+    with patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
+        return_value=fake_token_obj,
+    ), patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
+        return_value=[fake_key],
+    ), patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.jwt.decode",
+        side_effect=fake_decode,
     ):
         await OAuth2ProviderRecipe.get_instance().recipe_implementation.validate_oauth2_access_token(
             token="some-jwt",
@@ -143,19 +138,15 @@ async def test_validate_access_token_falls_back_to_rs256_when_jwk_has_no_algorit
         captured_algorithms.append(algorithms)
         return {"stt": 1}
 
-    with (
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
-            return_value=fake_token_obj,
-        ),
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
-            return_value=[fake_key],
-        ),
-        patch(
-            "supertokens_python.recipe.oauth2provider.recipe_implementation.jwt.decode",
-            side_effect=fake_decode,
-        ),
+    with patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
+        return_value=fake_token_obj,
+    ), patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
+        return_value=[fake_key],
+    ), patch(
+        "supertokens_python.recipe.oauth2provider.recipe_implementation.jwt.decode",
+        side_effect=fake_decode,
     ):
         await OAuth2ProviderRecipe.get_instance().recipe_implementation.validate_oauth2_access_token(
             token="some-jwt",
@@ -165,21 +156,3 @@ async def test_validate_access_token_falls_back_to_rs256_when_jwk_has_no_algorit
         )
 
     assert captured_algorithms == [["RS256"]]
-
-
-@min_api_version("2.14")
-async def test_oauth2provider_reset_clears_session_jwks_cache():
-    """reset() on the OAuth2 provider recipe must also drop the session
-    recipe's JWKS cache, so a fresh recipe instance against a new core
-    doesn't reuse stale keys from a previous one."""
-    import os
-
-    os.environ["SUPERTOKENS_ENV"] = "testing"
-    _init_recipe()
-
-    with patch(
-        "supertokens_python.recipe.session.jwks.reset_jwks_cache"
-    ) as mocked_reset:
-        OAuth2ProviderRecipe.reset()
-
-    mocked_reset.assert_called_once()

--- a/tests/oauth2provider/test_jwks_validation.py
+++ b/tests/oauth2provider/test_jwks_validation.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Plan 3 regression tests: validate_oauth2_access_token must
+(a) use the JWK's declared algorithm rather than hardcoded RS256, and
+(b) raise a clear key/signature error when no matching JWK is found —
+not fall through to 'Wrong token type'.
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+from pytest import mark, raises
+from supertokens_python import init
+from supertokens_python.recipe import oauth2provider, session
+from supertokens_python.recipe.oauth2provider.recipe import OAuth2ProviderRecipe
+
+from tests.utils import (
+    get_new_core_app_url,
+    get_st_init_args,
+    min_api_version,
+)
+
+pytestmark = mark.asyncio
+
+
+def _init_recipe():
+    init(
+        **get_st_init_args(
+            url=get_new_core_app_url(),
+            recipe_list=[
+                session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+                oauth2provider.init(),
+            ],
+        )
+    )
+
+
+@min_api_version("2.14")
+async def test_validate_access_token_raises_clear_error_when_no_matching_key():
+    """When the JWKS doesn't have a matching key for the token's kid we must
+    surface a key/signature error, not 'Wrong token type'. Previously the
+    empty-keys path silently produced an empty payload and then failed the
+    payload['stt'] != 1 check, masking the real cause."""
+    _init_recipe()
+
+    fake_token_obj = MagicMock()
+    fake_token_obj.kid = "missing-kid"
+
+    with (
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
+            return_value=fake_token_obj,
+        ),
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
+            return_value=[],
+        ),
+    ):
+        with raises(Exception, match="No JWKS key matching kid"):
+            await OAuth2ProviderRecipe.get_instance().recipe_implementation.validate_oauth2_access_token(
+                token="some-jwt",
+                requirements=None,
+                check_database=False,
+                user_context={},
+            )
+
+
+@min_api_version("2.14")
+async def test_validate_access_token_uses_algorithm_from_jwk():
+    """When the matching JWK declares algorithm_name='ES256', jwt.decode must
+    be called with algorithms=['ES256'], not the previously-hardcoded
+    ['RS256']. The fallback to 'RS256' is preserved when the JWK doesn't
+    declare an algorithm."""
+    _init_recipe()
+
+    fake_token_obj = MagicMock()
+    fake_token_obj.kid = "es-kid"
+
+    fake_key = MagicMock()
+    fake_key.algorithm_name = "ES256"
+    fake_key.key = "fake-key-material"
+
+    captured_algorithms: List[Optional[List[str]]] = []
+
+    def fake_decode(
+        *_args: Any, algorithms: Optional[List[str]] = None, **_kwargs: Any
+    ) -> Dict[str, Any]:
+        captured_algorithms.append(algorithms)
+        return {"stt": 1, "tId": "public", "sessionHandle": "handle-1"}
+
+    with (
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
+            return_value=fake_token_obj,
+        ),
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
+            return_value=[fake_key],
+        ),
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.jwt.decode",
+            side_effect=fake_decode,
+        ),
+    ):
+        await OAuth2ProviderRecipe.get_instance().recipe_implementation.validate_oauth2_access_token(
+            token="some-jwt",
+            requirements=None,
+            check_database=False,
+            user_context={},
+        )
+
+    assert captured_algorithms == [["ES256"]]
+
+
+@min_api_version("2.14")
+async def test_validate_access_token_falls_back_to_rs256_when_jwk_has_no_algorithm():
+    _init_recipe()
+
+    fake_token_obj = MagicMock()
+    fake_token_obj.kid = "no-alg-kid"
+
+    fake_key = MagicMock()
+    fake_key.algorithm_name = None
+    fake_key.key = "fake-key-material"
+
+    captured_algorithms: List[Optional[List[str]]] = []
+
+    def fake_decode(
+        *_args: Any, algorithms: Optional[List[str]] = None, **_kwargs: Any
+    ) -> Dict[str, Any]:
+        captured_algorithms.append(algorithms)
+        return {"stt": 1}
+
+    with (
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.parse_jwt_without_signature_verification",
+            return_value=fake_token_obj,
+        ),
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.get_latest_keys",
+            return_value=[fake_key],
+        ),
+        patch(
+            "supertokens_python.recipe.oauth2provider.recipe_implementation.jwt.decode",
+            side_effect=fake_decode,
+        ),
+    ):
+        await OAuth2ProviderRecipe.get_instance().recipe_implementation.validate_oauth2_access_token(
+            token="some-jwt",
+            requirements=None,
+            check_database=False,
+            user_context={},
+        )
+
+    assert captured_algorithms == [["RS256"]]
+
+
+@min_api_version("2.14")
+async def test_oauth2provider_reset_clears_session_jwks_cache():
+    """reset() on the OAuth2 provider recipe must also drop the session
+    recipe's JWKS cache, so a fresh recipe instance against a new core
+    doesn't reuse stale keys from a previous one."""
+    import os
+
+    os.environ["SUPERTOKENS_ENV"] = "testing"
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.recipe.session.jwks.reset_jwks_cache"
+    ) as mocked_reset:
+        OAuth2ProviderRecipe.reset()
+
+    mocked_reset.assert_called_once()

--- a/tests/oauth2provider/test_oauth_error_responses.py
+++ b/tests/oauth2provider/test_oauth_error_responses.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Plan 2 regression tests: when the SuperTokens core returns
+`{"status": "OAUTH_ERROR", ...}` for an OAuth2 admin call, the recipe
+must surface an `ErrorOAuth2Response` instead of crashing or silently
+treating the error as inactive/unknown. Public type signatures were
+widened to admit the error variant in 0.32.0.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from pytest import mark
+from supertokens_python import init
+from supertokens_python.recipe import oauth2provider, session
+from supertokens_python.recipe.oauth2provider.interfaces import (
+    ActiveTokenResponse,
+    ErrorOAuth2Response,
+    InactiveTokenResponse,
+    RedirectResponse,
+)
+from supertokens_python.recipe.oauth2provider.recipe import OAuth2ProviderRecipe
+
+from tests.utils import (
+    get_new_core_app_url,
+    get_st_init_args,
+    min_api_version,
+)
+
+pytestmark = mark.asyncio
+
+
+def _init_recipe():
+    init(
+        **get_st_init_args(
+            url=get_new_core_app_url(),
+            recipe_list=[
+                session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+                oauth2provider.init(),
+            ],
+        )
+    )
+
+
+@min_api_version("2.14")
+async def test_introspect_token_surfaces_oauth_error():
+    """The core can return OAUTH_ERROR (e.g. core misconfiguration). Previously
+    Python collapsed this onto the inactive branch, which masked backend
+    failures as 'token inactive'. We now return ErrorOAuth2Response so
+    callers can distinguish."""
+    _init_recipe()
+
+    core_response = {
+        "status": "OAUTH_ERROR",
+        "statusCode": 500,
+        "error": "server_error",
+        "errorDescription": "internal server error",
+    }
+
+    with patch(
+        "supertokens_python.querier.Querier.send_post_request",
+        new=AsyncMock(return_value=core_response),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.introspect_token(
+            token="st_rt_abc",
+            scopes=None,
+            user_context={},
+        )
+
+    assert isinstance(result, ErrorOAuth2Response)
+    assert result.error == "server_error"
+    assert result.error_description == "internal server error"
+    assert result.status_code == 500
+
+
+@min_api_version("2.14")
+async def test_introspect_token_active_branch_unchanged():
+    """Active introspection still returns ActiveTokenResponse — the new
+    error branch must not regress the OK path."""
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.querier.Querier.send_post_request",
+        new=AsyncMock(
+            return_value={"active": True, "sub": "user-1", "scope": "openid"}
+        ),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.introspect_token(
+            token="st_rt_abc",
+            scopes=None,
+            user_context={},
+        )
+
+    assert isinstance(result, ActiveTokenResponse)
+    assert result.payload["sub"] == "user-1"
+
+
+@min_api_version("2.14")
+async def test_introspect_token_inactive_branch_unchanged():
+    """Inactive introspection still returns InactiveTokenResponse."""
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.querier.Querier.send_post_request",
+        new=AsyncMock(return_value={"active": False}),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.introspect_token(
+            token="st_rt_abc",
+            scopes=None,
+            user_context={},
+        )
+
+    assert isinstance(result, InactiveTokenResponse)
+
+
+@min_api_version("2.14")
+async def test_accept_login_request_surfaces_oauth_error():
+    """A consent challenge can expire between issuance and acceptance.
+    Previously Python KeyError'd on response['redirectTo']; now we return
+    ErrorOAuth2Response."""
+    _init_recipe()
+
+    core_response = {
+        "status": "OAUTH_ERROR",
+        "statusCode": 410,
+        "error": "invalid_request",
+        "errorDescription": "challenge expired",
+    }
+
+    with patch(
+        "supertokens_python.querier.Querier.send_put_request",
+        new=AsyncMock(return_value=core_response),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.accept_login_request(
+            challenge="some-challenge",
+            acr=None,
+            amr=None,
+            context=None,
+            extend_session_lifespan=None,
+            identity_provider_session_id=None,
+            subject="user-1",
+            user_context={},
+        )
+
+    assert isinstance(result, ErrorOAuth2Response)
+    assert result.error == "invalid_request"
+    assert result.error_description == "challenge expired"
+    assert result.status_code == 410
+
+
+@min_api_version("2.14")
+async def test_accept_login_request_ok_branch_unchanged():
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.querier.Querier.send_put_request",
+        new=AsyncMock(return_value={"redirectTo": "http://example.com/callback"}),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.accept_login_request(
+            challenge="some-challenge",
+            acr=None,
+            amr=None,
+            context=None,
+            extend_session_lifespan=None,
+            identity_provider_session_id=None,
+            subject="user-1",
+            user_context={},
+        )
+
+    assert isinstance(result, RedirectResponse)
+    assert "example.com/callback" in result.redirect_to
+
+
+@min_api_version("2.14")
+async def test_reject_login_request_surfaces_oauth_error():
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.querier.Querier.send_put_request",
+        new=AsyncMock(
+            return_value={
+                "status": "OAUTH_ERROR",
+                "statusCode": 410,
+                "error": "invalid_request",
+                "errorDescription": "challenge expired",
+            }
+        ),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.reject_login_request(
+            challenge="some-challenge",
+            error=ErrorOAuth2Response(
+                error="access_denied",
+                error_description="user rejected consent",
+            ),
+            user_context={},
+        )
+
+    assert isinstance(result, ErrorOAuth2Response)
+    assert result.error == "invalid_request"
+
+
+@min_api_version("2.14")
+async def test_accept_consent_request_surfaces_oauth_error():
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.querier.Querier.send_put_request",
+        new=AsyncMock(
+            return_value={
+                "status": "OAUTH_ERROR",
+                "statusCode": 410,
+                "error": "invalid_request",
+                "errorDescription": "consent challenge expired",
+            }
+        ),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.accept_consent_request(
+            challenge="some-challenge",
+            context=None,
+            grant_access_token_audience=None,
+            grant_scope=None,
+            handled_at=None,
+            tenant_id="public",
+            rsub="user-1",
+            session_handle="handle-1",
+            initial_access_token_payload=None,
+            initial_id_token_payload=None,
+            user_context={},
+        )
+
+    assert isinstance(result, ErrorOAuth2Response)
+    assert result.error_description == "consent challenge expired"
+
+
+@min_api_version("2.14")
+async def test_reject_consent_request_surfaces_oauth_error():
+    _init_recipe()
+
+    with patch(
+        "supertokens_python.querier.Querier.send_put_request",
+        new=AsyncMock(
+            return_value={
+                "status": "OAUTH_ERROR",
+                "statusCode": 410,
+                "error": "invalid_request",
+                "errorDescription": "consent challenge expired",
+            }
+        ),
+    ):
+        result = await OAuth2ProviderRecipe.get_instance().recipe_implementation.reject_consent_request(
+            challenge="some-challenge",
+            error=ErrorOAuth2Response(
+                error="access_denied",
+                error_description="user rejected",
+            ),
+            user_context={},
+        )
+
+    assert isinstance(result, ErrorOAuth2Response)
+    assert result.error_description == "consent challenge expired"

--- a/tests/oauth2provider/test_public_surface.py
+++ b/tests/oauth2provider/test_public_surface.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0 (the
+# "License") as published by the Apache Software Foundation.
+#
+# You may not use this file except in compliance with the License. You may
+# obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Plan 5 regression tests:
+
+- N18: get_default_user_info_payload should not emit `phoneNumber: None`
+  for users without a phone. Matches the behavior of the access-token
+  and id-token builders, and Node's omit-on-undefined serialization.
+- Sync/async signature parity for create_token_for_client_credentials:
+  client_secret is Optional[str] in both wrappers.
+"""
+
+import inspect
+
+from pytest import mark
+from supertokens_python import init
+from supertokens_python.recipe import oauth2provider, session
+from supertokens_python.recipe.oauth2provider import asyncio as oauth_async
+from supertokens_python.recipe.oauth2provider import syncio as oauth_sync
+from supertokens_python.recipe.oauth2provider.recipe import OAuth2ProviderRecipe
+from supertokens_python.recipe.webauthn.types.base import WebauthnInfo
+from supertokens_python.types import LoginMethod, User
+
+from tests.utils import (
+    get_new_core_app_url,
+    get_st_init_args,
+    min_api_version,
+)
+
+pytestmark = mark.asyncio
+
+
+def _user_without_phone() -> User:
+    user_id = "user-no-phone"
+    return User(
+        user_id=user_id,
+        is_primary_user=True,
+        tenant_ids=["public"],
+        emails=["x@example.com"],
+        phone_numbers=[],
+        third_party=[],
+        webauthn=WebauthnInfo(credential_ids=[]),
+        login_methods=[
+            LoginMethod(
+                recipe_id="emailpassword",
+                recipe_user_id=user_id,
+                tenant_ids=["public"],
+                email="x@example.com",
+                phone_number=None,
+                third_party=None,
+                webauthn=None,
+                time_joined=0,
+                verified=True,
+            )
+        ],
+        time_joined=0,
+    )
+
+
+@min_api_version("2.14")
+async def test_user_info_payload_omits_phone_number_when_absent():
+    """N18: when the user has no phone, phoneNumber must be absent from the
+    user_info payload — not present as null. Matches the access-token and
+    id-token builders, and Node's serialization."""
+    init(
+        **get_st_init_args(
+            url=get_new_core_app_url(),
+            recipe_list=[
+                session.init(get_token_transfer_method=lambda _, __, ___: "cookie"),
+                oauth2provider.init(),
+            ],
+        )
+    )
+
+    payload = await OAuth2ProviderRecipe.get_instance().get_default_user_info_payload(
+        user=_user_without_phone(),
+        access_token_payload={"sub": "user-no-phone"},
+        scopes=["phoneNumber"],
+        tenant_id="public",
+        user_context={},
+    )
+
+    assert "phoneNumber" not in payload
+    # The companion `phoneNumber_verified` key still gets emitted (matches
+    # Node's behavior of emitting the verified flag even when phone is
+    # absent).
+    assert payload.get("phoneNumber_verified") is False
+    assert payload.get("phoneNumbers") == []
+
+
+def test_create_token_for_client_credentials_sync_async_signature_parity():
+    """The async and sync wrappers for create_token_for_client_credentials
+    must have the same client_secret signature. Previously async accepted
+    Optional[str] but sync required str."""
+    async_sig = inspect.signature(oauth_async.create_token_for_client_credentials)
+    sync_sig = inspect.signature(oauth_sync.create_token_for_client_credentials)
+
+    # Annotations are strings under `from __future__ import annotations`.
+    assert (
+        async_sig.parameters["client_secret"].annotation
+        == sync_sig.parameters["client_secret"].annotation
+    )
+    assert (
+        async_sig.parameters["client_secret"].default
+        == sync_sig.parameters["client_secret"].default
+    )
+    assert sync_sig.parameters["client_secret"].default is None

--- a/tests/test-server/app.py
+++ b/tests/test-server/app.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import os
+import sys
 import traceback
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
 
@@ -83,7 +84,20 @@ from webauthn import add_webauthn_routes
 
 from supertokens import add_supertokens_routes  # pylint: disable=import-error
 
+# Optional timing instrumentation, gated by LOG_TEST_TIMINGS=1.
+# tests/test-server/app.py is at depth 2 (tests/<dir>/app.py).
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+from tests._test_timing import (  # noqa: E402
+    install_flask_request_timing,
+    install_querier_timing,
+)
+
+install_querier_timing()
+
 app = Flask(__name__)
+install_flask_request_timing(app)
 Middleware(app)
 
 # Global variables


### PR DESCRIPTION
## Summary

Follow-up to #634, working through the rest of the oauth2provider audit findings plus a small CI-time win. Five commits, each independently scoped:

- **OAUTH_ERROR surfacing** (`c948520c`) — `introspect_token`, `validate_oauth2_refresh_token`, `accept_login_request`, `reject_login_request`, `accept_consent_request`, `reject_consent_request` now return an `ErrorOAuth2Response` variant when the core responds with `status: "OAUTH_ERROR"`. Previously the introspect path silently treated core errors as "token inactive"; the accept/reject paths raised `KeyError` on the missing `redirectTo`. Public types widened on `RecipeInterface`, `asyncio`, `syncio`, `APIInterface`, and `api/utils.login_get` callers. **Typed-API breaking change** — custom overrides need to widen their declared return types.

- **JWKS handling** (`8d20bbf3`) — `validate_oauth2_access_token` now uses the algorithm declared in the matching JWK (falls back to RS256) instead of always passing `algorithms=['RS256']`; raises a clear key/signature error when no JWK matches the token's `kid` (was misreporting as "Wrong token type"); and `OAuth2ProviderRecipe.reset()` drops the session JWKS cache so test runs against a different core don't reuse stale keys (matches Node's `resetCombinedJWKS`).

- **Cookie handling** (`15ad75ff`) — `api/auth.py` and `api/login.py` no longer crash with `dateutil.parser.parse('')` `ValueError` when the core sends a cookie without an `Expires` attribute (a session cookie); a shared `parse_expires_ms_or_default` helper falls back to a 1-hour TTL. `get_merged_cookies` now parses `Set-Cookie` attributes via `SimpleCookie` and drops cookies whose `Expires` is in the past — the core's idiom for "delete this cookie" was being silently ignored, so logout cookies survived the merge. Matches Node's `setCookieParser` behavior.

- **Public-surface consistency** (`e4ffea0a`) — `get_default_user_info_payload` no longer emits `phoneNumber: null` when the user has no phone (matches the access-token / id-token builders, and Node's omit-on-undefined). `syncio.create_token_for_client_credentials` accepts `client_secret` as `Optional[str] = None`, matching the asyncio wrapper.

- **CI: pip caching** (`08ed9f1c`) — all four matrix workflows now pass `cache: 'pip'` to `actions/setup-python` keyed on `dev-requirements.txt` + `setup.py`. Cuts the venv-install step from ~30–90s to a few seconds when the dep set hasn't changed. Also adds the missing `actions/setup-python` step to `backend-sdk-testing`, which previously declared `py-version: 3.8–3.13` on its matrix but silently used whatever Python the runner shipped.

## Out of scope for this PR

Considered and left out from the audit:
- **`revoke_token` Basic-auth handling** — Node's behavior is to send a malformed Basic header (`base64(clientId + ":undefined")`) when secret is missing; replicating that bug isn't useful, and changing semantics in either direction is a separate decision.
- **`is_in_serverless_env` on `APIOptions`** — Python doesn't model serverless env at the recipe layer; this is a deeper architectural divergence.
- **`OAuth2Client` constructor defaults** — works correctly through `from_json` (the primary construction path); adding `__init__` defaults is a larger refactor.

## Test plan

- [x] 25 new regression tests across `tests/oauth2provider/test_oauth_error_responses.py`, `test_jwks_validation.py`, `test_cookie_handling.py`, `test_public_surface.py`
- [x] `pytest tests/oauth2provider/ tests/userroles/` — 57 passed locally
- [x] `pre-commit run --all-files` — clean
- [x] `pyright` — clean
- [ ] CI green
- [ ] Verify pip-cache hit on a second run (will only show on the second run after merge)

## Versioning

One `Breaking Changes` fragment + four `Fixed` fragments + one `Infrastructure` fragment under `.changes/unreleased/`. The `Breaking Changes` kind auto-bumps to a minor version (per `.changie.yaml`'s `auto: minor` while pre-1.0), so the next release will roll to `0.32.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)