### PR TITLE
fix: remove double verification of credentials in webauthn signin

### DIFF
--- a/.changes/unreleased/Fixed-20260723-120835.yaml
+++ b/.changes/unreleased/Fixed-20260723-120835.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'webauthn: fix sign in failing for counter-incrementing authenticators (e.g. Windows Hello) — the assertion was verified against the core twice'
+time: 2026-07-23T12:08:35.531645+02:00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
-
 ## [0.31.3] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+- webauthn: fix sign in failing for counter-incrementing authenticators (e.g. Windows Hello) — the assertion was verified against the core twice ([supertokens-core#1195](https://github.com/supertokens/supertokens-core/issues/1195)). Adds `complete_sign_in` to the recipe interface; `sign_in_post` no longer calls `sign_in`, so move `sign_in` override logic for the API flow to `complete_sign_in`. Masked sign-in errors are now debug-logged
+
+
 ## [0.31.3] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- webauthn: fix sign in failing for counter-incrementing authenticators (e.g. Windows Hello) — the assertion was verified against the core twice ([supertokens-core#1195](https://github.com/supertokens/supertokens-core/issues/1195)). Adds `complete_sign_in` to the recipe interface; `sign_in_post` no longer calls `sign_in`, so move `sign_in` override logic for the API flow to `complete_sign_in`. Masked sign-in errors are now debug-logged
-
-
 ## [0.31.3] - 2026-05-06
 
 ### Fixed

--- a/supertokens_python/recipe/webauthn/api/implementation.py
+++ b/supertokens_python/recipe/webauthn/api/implementation.py
@@ -381,6 +381,12 @@ class APIImplementation(APIInterface):
         )
 
         if verify_result_response.status != "OK":
+            reason = getattr(verify_result_response, "reason", None)
+            log_debug_message(
+                "sign_in_post: returning INVALID_CREDENTIALS_ERROR because "
+                f"verify_credentials returned {verify_result_response.status}"
+                + (f" (reason: {reason})" if reason is not None else "")
+            )
             return InvalidCredentialsErrorResponse()
 
         generated_options_response = (
@@ -392,6 +398,10 @@ class APIImplementation(APIInterface):
         )
 
         if generated_options_response.status != "OK":
+            log_debug_message(
+                "sign_in_post: returning INVALID_CREDENTIALS_ERROR because "
+                f"get_generated_options returned {generated_options_response.status}"
+            )
             return InvalidCredentialsErrorResponse()
 
         async def check_credentials_on_tenant(tenant_id: str):
@@ -470,29 +480,18 @@ class APIImplementation(APIInterface):
             # Fake emails cannot be used as a first factor
             return InvalidCredentialsErrorResponse()
 
-        sign_in_response = await options.recipe_implementation.sign_in(
-            webauthn_generated_options_id=webauthn_generated_options_id,
-            credential=credential,
+        # The credential was already verified against the core by the verify_credentials
+        # call above, so we only run the post-verification steps here. Calling sign_in
+        # (which verifies again) would present the same assertion to the core twice and
+        # trip its signature-counter clone detection for counter-incrementing
+        # authenticators (https://github.com/supertokens/supertokens-core/issues/1195).
+        sign_in_response = await options.recipe_implementation.complete_sign_in(
+            verified_credentials=verify_result_response,
             session=session,
             should_try_linking_with_session_user=should_try_linking_with_session_user,
             tenant_id=tenant_id,
             user_context=user_context,
         )
-
-        if isinstance(sign_in_response, InvalidCredentialsErrorResponse):
-            return sign_in_response
-
-        if isinstance(
-            sign_in_response,
-            (
-                InvalidOptionsErrorResponse,
-                InvalidAuthenticatorErrorResponse,
-                CredentialNotFoundErrorResponse,
-                UnknownUserIdErrorResponse,
-                OptionsNotFoundErrorResponse,
-            ),
-        ):
-            return InvalidCredentialsErrorResponse()
 
         if sign_in_response.status != "OK":
             return SignInNotAllowedErrorResponse(

--- a/supertokens_python/recipe/webauthn/interfaces/recipe.py
+++ b/supertokens_python/recipe/webauthn/interfaces/recipe.py
@@ -500,6 +500,26 @@ class RecipeInterface(BaseRecipeInterface):
     ) -> Union[SignInResponse, SignInErrorResponse]: ...
 
     @abstractmethod
+    async def complete_sign_in(
+        self,
+        *,
+        verified_credentials: VerifyCredentialsResponse,
+        session: Optional[SessionContainer] = None,
+        should_try_linking_with_session_user: Optional[bool] = None,
+        tenant_id: str,
+        user_context: UserContext,
+    ) -> Union[SignInResponse, LinkingToSessionUserFailedError]:
+        """
+        Runs the post-verification part of sign in (email verification propagation and
+        account linking) against an already-verified credential. Called by sign_in_post
+        after its verify_credentials guard so that the assertion is verified against the
+        core exactly once per request — verifying the same assertion twice trips the
+        core's signature-counter clone detection for counter-incrementing authenticators
+        (https://github.com/supertokens/supertokens-core/issues/1195).
+        """
+        ...
+
+    @abstractmethod
     async def verify_credentials(
         self,
         *,

--- a/supertokens_python/recipe/webauthn/recipe_implementation.py
+++ b/supertokens_python/recipe/webauthn/recipe_implementation.py
@@ -72,6 +72,7 @@ from supertokens_python.recipe.webauthn.interfaces.recipe import (
     VerifyCredentialsResponse,
 )
 from supertokens_python.recipe.webauthn.types.config import NormalisedWebauthnConfig
+from supertokens_python.types.auth_utils import LinkingToSessionUserFailedError
 from supertokens_python.types.base import RecipeUserId, User, UserContext
 from supertokens_python.types.response import OkResponseBaseModel
 
@@ -312,29 +313,46 @@ class RecipeImplementation(RecipeInterface):
         if verify_creds_response.status != "OK":
             return verify_creds_response
 
-        signed_in_user = verify_creds_response.user
+        return await self.complete_sign_in(
+            verified_credentials=verify_creds_response,
+            session=session,
+            should_try_linking_with_session_user=should_try_linking_with_session_user,
+            tenant_id=tenant_id,
+            user_context=user_context,
+        )
+
+    async def complete_sign_in(
+        self,
+        *,
+        verified_credentials: VerifyCredentialsResponse,
+        session: Optional[SessionContainer] = None,
+        should_try_linking_with_session_user: Optional[bool] = None,
+        tenant_id: str,
+        user_context: UserContext,
+    ) -> Union[SignInResponse, LinkingToSessionUserFailedError]:
+        signed_in_user = verified_credentials.user
 
         login_method = next(
             filter(
                 lambda lm: (
                     lm.recipe_user_id.get_as_string()
-                    == verify_creds_response.recipe_user_id.get_as_string()
+                    == verified_credentials.recipe_user_id.get_as_string()
                 ),
-                verify_creds_response.user.login_methods,
+                verified_credentials.user.login_methods,
             )
         )
 
         if not login_method.verified:
             await AccountLinkingRecipe.get_instance().verify_email_for_recipe_user_if_linked_accounts_are_verified(
-                user=verify_creds_response.user,
-                recipe_user_id=verify_creds_response.recipe_user_id,
+                user=verified_credentials.user,
+                recipe_user_id=verified_credentials.recipe_user_id,
                 user_context=user_context,
             )
 
             # We do this so that we get the updated user (in case the above
             # function updated the verification status) and can return that
             updated_user = await get_user(
-                verify_creds_response.recipe_user_id.get_as_string(), user_context
+                verified_credentials.recipe_user_id.get_as_string(), user_context
             )
 
             if updated_user is not None:
@@ -342,8 +360,8 @@ class RecipeImplementation(RecipeInterface):
 
         link_result = await link_to_session_if_provided_else_create_primary_user_id_or_link_by_account_info(
             tenant_id=tenant_id,
-            input_user=verify_creds_response.user,
-            recipe_user_id=verify_creds_response.recipe_user_id,
+            input_user=verified_credentials.user,
+            recipe_user_id=verified_credentials.recipe_user_id,
             session=session,
             should_try_linking_with_session_user=should_try_linking_with_session_user,
             user_context=user_context,
@@ -357,7 +375,7 @@ class RecipeImplementation(RecipeInterface):
         return SignInResponse(
             status="OK",
             user=signed_in_user,
-            recipe_user_id=verify_creds_response.recipe_user_id,
+            recipe_user_id=verified_credentials.recipe_user_id,
         )
 
     async def verify_credentials(

--- a/tests/webauthn/soft_authenticator.py
+++ b/tests/webauthn/soft_authenticator.py
@@ -1,0 +1,173 @@
+"""
+A minimal software WebAuthn authenticator with full control over the signature
+counter (signCount).
+
+Real hardware authenticators (Windows Hello, security keys) increment the
+counter on every assertion, while Apple/Google passkeys keep it at 0 forever —
+which skips the core's clone-detection check (WebAuthn L3 section 7.2 step 24)
+entirely. Tests that only ever present signCount = 0 therefore cannot catch
+counter-related regressions such as
+https://github.com/supertokens/supertokens-core/issues/1195.
+
+Produces `fmt: "none"` attestations, which the core accepts because it verifies
+with webauthn4j's non-strict manager.
+"""
+
+import base64
+import hashlib
+import json
+import secrets
+from typing import Any, Dict, List, Tuple, Union
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+
+FLAG_UP = 0x01
+FLAG_UV = 0x04
+FLAG_AT = 0x40
+
+CborValue = Union[int, str, bytes, List[Tuple[Any, Any]]]
+
+
+def _cbor_head(major: int, n: int) -> bytes:
+    if n < 24:
+        return bytes([(major << 5) | n])
+    if n < 0x100:
+        return bytes([(major << 5) | 24, n])
+    if n < 0x10000:
+        return bytes([(major << 5) | 25]) + n.to_bytes(2, "big")
+    return bytes([(major << 5) | 26]) + n.to_bytes(4, "big")
+
+
+def cbor_encode(value: CborValue) -> bytes:
+    """
+    Minimal CBOR encoder covering only what a "none" attestation needs.
+    A list of (key, value) tuples is encoded as a CBOR map — this preserves
+    the integer keys that COSE keys require.
+    """
+    if isinstance(value, bool):
+        raise TypeError("booleans not supported")
+    if isinstance(value, int):
+        return _cbor_head(0, value) if value >= 0 else _cbor_head(1, -1 - value)
+    if isinstance(value, str):
+        encoded = value.encode()
+        return _cbor_head(3, len(encoded)) + encoded
+    if isinstance(value, bytes):
+        return _cbor_head(2, len(value)) + value
+    if isinstance(value, list):
+        out = _cbor_head(5, len(value))
+        for key, val in value:
+            out += cbor_encode(key) + cbor_encode(val)
+        return out
+    raise TypeError(f"unsupported CBOR value type: {type(value)}")
+
+
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+class SoftAuthenticator:
+    """
+    One instance == one credential (one P-256 keypair). The `sign_count`
+    arguments give tests full control over the counter values reported to the
+    Relying Party.
+    """
+
+    def __init__(self, *, rp_id: str, origin: str):
+        self.rp_id_hash = hashlib.sha256(rp_id.encode()).digest()
+        self.origin = origin
+        self.private_key = ec.generate_private_key(ec.SECP256R1())
+        public_numbers = self.private_key.public_key().public_numbers()
+        self.x = public_numbers.x.to_bytes(32, "big")
+        self.y = public_numbers.y.to_bytes(32, "big")
+        self.credential_id = secrets.token_bytes(32)
+
+    def create_attestation(
+        self, register_options: Dict[str, Any], *, sign_count: int = 0
+    ) -> Dict[str, Any]:
+        """
+        Build a RegistrationPayload for POST /auth/webauthn/signup from a
+        response body of POST /auth/webauthn/options/register. `sign_count`
+        becomes the initial counter value stored by the RP.
+        """
+        client_data = json.dumps(
+            {
+                "type": "webauthn.create",
+                "challenge": register_options["challenge"],
+                "origin": self.origin,
+                "crossOrigin": False,
+            }
+        ).encode()
+
+        # COSE_Key: kty(1)=EC2(2), alg(3)=ES256(-7), crv(-1)=P-256(1), x(-2), y(-3)
+        cose_key = cbor_encode([(1, 2), (3, -7), (-1, 1), (-2, self.x), (-3, self.y)])
+
+        auth_data = (
+            self.rp_id_hash
+            + bytes([FLAG_UP | FLAG_UV | FLAG_AT])
+            + sign_count.to_bytes(4, "big")
+            + bytes(16)  # aaguid (zero = "none")
+            + len(self.credential_id).to_bytes(2, "big")
+            + self.credential_id
+            + cose_key
+        )
+
+        attestation_object = cbor_encode(
+            [("fmt", "none"), ("attStmt", []), ("authData", auth_data)]
+        )
+
+        return {
+            "id": b64url(self.credential_id),
+            "rawId": b64url(self.credential_id),
+            "response": {
+                "clientDataJSON": b64url(client_data),
+                "attestationObject": b64url(attestation_object),
+                "transports": ["internal"],
+            },
+            "type": "public-key",
+            "clientExtensionResults": {},
+            "authenticatorAttachment": "platform",
+        }
+
+    def create_assertion(
+        self,
+        signin_options: Dict[str, Any],
+        *,
+        sign_count: int,
+        user_handle: str,
+    ) -> Dict[str, Any]:
+        """
+        Build an AuthenticationPayload for POST /auth/webauthn/signin from a
+        response body of POST /auth/webauthn/options/signin. `sign_count` is
+        the counter value this assertion reports; `user_handle` is
+        register_options["user"]["id"] from registration.
+        """
+        client_data = json.dumps(
+            {
+                "type": "webauthn.get",
+                "challenge": signin_options["challenge"],
+                "origin": self.origin,
+                "crossOrigin": False,
+            }
+        ).encode()
+
+        auth_data = (
+            self.rp_id_hash + bytes([FLAG_UP | FLAG_UV]) + sign_count.to_bytes(4, "big")
+        )
+        signed_over = auth_data + hashlib.sha256(client_data).digest()
+        # DER-encoded ECDSA, as WebAuthn ES256 requires
+        signature = self.private_key.sign(signed_over, ec.ECDSA(hashes.SHA256()))
+
+        return {
+            "id": b64url(self.credential_id),
+            "rawId": b64url(self.credential_id),
+            "response": {
+                "clientDataJSON": b64url(client_data),
+                "authenticatorData": b64url(auth_data),
+                "signature": b64url(signature),
+                "userHandle": user_handle,
+            },
+            "type": "public-key",
+            "clientExtensionResults": {},
+            "authenticatorAttachment": "platform",
+        }

--- a/tests/webauthn/test_sign_in_double_verify.py
+++ b/tests/webauthn/test_sign_in_double_verify.py
@@ -1,0 +1,195 @@
+"""
+Regression tests for https://github.com/supertokens/supertokens-core/issues/1195
+
+sign_in_post used to verify the same assertion twice against the core
+(verify_credentials at the top, then sign_in -> verify_credentials again). The
+core persists the signature counter on every verification, so the second call
+presented a non-increasing signCount and webauthn4j rejected it as a cloned
+authenticator ("Malicious counter value is detected..."), which sign_in_post
+masked as INVALID_CREDENTIALS_ERROR.
+
+This only triggered for authenticators that actually increment signCount
+(Windows Hello, security keys, Chrome virtual authenticators). Apple and Google
+passkeys keep signCount at 0 forever, which skips the check and hid the bug —
+hence the zero-counter control test below.
+"""
+
+import random
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from pytest import fixture, mark
+from supertokens_python import InputAppInfo, SupertokensConfig, init
+from supertokens_python.framework.fastapi import get_middleware
+from supertokens_python.recipe import session, webauthn
+from supertokens_python.recipe.webauthn import WebauthnConfig
+from supertokens_python.recipe.webauthn.interfaces.recipe import AuthenticationPayload
+from supertokens_python.recipe.webauthn.recipe import WebauthnRecipe
+from supertokens_python.types.base import UserContext
+from tests.testclient import TestClientWithNoCookieJar as TestClient
+from tests.utils import get_new_core_app_url
+from tests.webauthn.soft_authenticator import SoftAuthenticator
+
+# Must be a consistent pair: the core validates that the origin host ends with
+# the relying party id. (The defaults derived from app_info — rpId = apiDomain
+# host, origin = websiteDomain — do NOT satisfy this, so we set them explicitly.)
+RP_ID = "supertokens.io"
+ORIGIN = "https://supertokens.io"
+
+
+async def _get_origin(**_: Any) -> str:
+    return ORIGIN
+
+
+@fixture(scope="function")
+def client() -> TestClient:
+    init(
+        supertokens_config=SupertokensConfig(get_new_core_app_url()),
+        app_info=InputAppInfo(
+            app_name="SuperTokens",
+            api_domain="api.supertokens.io",
+            website_domain="supertokens.io",
+            api_base_path="/auth",
+        ),
+        framework="fastapi",
+        mode="asgi",
+        recipe_list=[
+            webauthn.init(
+                WebauthnConfig(get_relying_party_id=RP_ID, get_origin=_get_origin)
+            ),
+            session.init(),
+        ],
+    )
+
+    app = FastAPI()
+    app.add_middleware(get_middleware())
+    return TestClient(app)
+
+
+def _post(client: TestClient, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+    response = client.post(path, json=body)
+    assert response.status_code == 200, f"{path} -> {response.status_code}: {response.text[:400]}"
+    return response.json()
+
+
+def _register_user(
+    client: TestClient, authenticator: SoftAuthenticator, *, sign_count: int
+) -> str:
+    """Registers a fresh user+passkey whose stored counter starts at `sign_count`;
+    returns the webauthn user handle."""
+    email = f"{random.random()}@supertokens.com".replace("0.", "")
+
+    register_options = _post(client, "/auth/webauthn/options/register", {"email": email})
+    assert register_options["status"] == "OK", register_options
+
+    sign_up_response = _post(
+        client,
+        "/auth/webauthn/signup",
+        {
+            "credential": authenticator.create_attestation(
+                register_options, sign_count=sign_count
+            ),
+            "webauthnGeneratedOptionsId": register_options["webauthnGeneratedOptionsId"],
+            "shouldTryLinkingWithSessionUser": False,
+        },
+    )
+    assert sign_up_response["status"] == "OK", sign_up_response
+
+    return register_options["user"]["id"]
+
+
+@mark.asyncio
+async def test_api_sign_in_succeeds_with_counter_incrementing_authenticator(
+    client: TestClient,
+):
+    """
+    THE REGRESSION TEST for core#1195: a single, legitimate sign-in API call
+    with an authenticator that increments its signature counter must succeed.
+    On the unfixed SDK the second internal verification saw the already
+    persisted counter and this returned INVALID_CREDENTIALS_ERROR.
+    """
+    authenticator = SoftAuthenticator(rp_id=RP_ID, origin=ORIGIN)
+    user_handle = _register_user(client, authenticator, sign_count=1)
+
+    signin_options = _post(client, "/auth/webauthn/options/signin", {})
+    assert signin_options["status"] == "OK", signin_options
+
+    sign_in_response = _post(
+        client,
+        "/auth/webauthn/signin",
+        {
+            "credential": authenticator.create_assertion(
+                signin_options, sign_count=2, user_handle=user_handle
+            ),
+            "webauthnGeneratedOptionsId": signin_options["webauthnGeneratedOptionsId"],
+            "shouldTryLinkingWithSessionUser": False,
+        },
+    )
+
+    assert sign_in_response["status"] == "OK", (
+        "A single sign-in with an incrementing signCount must succeed. Failure "
+        "here means sign_in_post verified the assertion against the core more "
+        "than once and tripped its own clone detection (supertokens-core#1195). "
+        f"Got: {sign_in_response}"
+    )
+
+
+@mark.asyncio
+async def test_direct_recipe_sign_in_succeeds_with_counter_incrementing_authenticator(
+    client: TestClient,
+):
+    """
+    Control: the same credential/assertion accepted via the recipe function,
+    which verifies exactly once. Proves the assertion and counter handling are
+    valid, isolating any API-layer double verification as the failure cause.
+    """
+    authenticator = SoftAuthenticator(rp_id=RP_ID, origin=ORIGIN)
+    user_handle = _register_user(client, authenticator, sign_count=1)
+
+    signin_options = _post(client, "/auth/webauthn/options/signin", {})
+    assert signin_options["status"] == "OK", signin_options
+
+    recipe = WebauthnRecipe.get_instance()
+    user_context: UserContext = {}
+    sign_in_result = await recipe.recipe_implementation.sign_in(
+        webauthn_generated_options_id=signin_options["webauthnGeneratedOptionsId"],
+        credential=AuthenticationPayload.model_validate(
+            authenticator.create_assertion(
+                signin_options, sign_count=2, user_handle=user_handle
+            )
+        ),
+        tenant_id="public",
+        session=None,
+        should_try_linking_with_session_user=False,
+        user_context=user_context,
+    )
+
+    assert sign_in_result.status == "OK", f"Got: {sign_in_result}"
+
+
+@mark.asyncio
+async def test_api_sign_in_succeeds_when_sign_count_stays_zero(client: TestClient):
+    """
+    Control: with signCount pinned to 0 (Apple/Google passkey behavior) the
+    spec skips the counter check entirely, so a double verification would go
+    unnoticed. This is why the bug was invisible in most manual testing.
+    """
+    authenticator = SoftAuthenticator(rp_id=RP_ID, origin=ORIGIN)
+    user_handle = _register_user(client, authenticator, sign_count=0)
+
+    signin_options = _post(client, "/auth/webauthn/options/signin", {})
+    assert signin_options["status"] == "OK", signin_options
+
+    sign_in_response = _post(
+        client,
+        "/auth/webauthn/signin",
+        {
+            "credential": authenticator.create_assertion(
+                signin_options, sign_count=0, user_handle=user_handle
+            ),
+            "webauthnGeneratedOptionsId": signin_options["webauthnGeneratedOptionsId"],
+            "shouldTryLinkingWithSessionUser": False,
+        },
+    )
+
+    assert sign_in_response["status"] == "OK", f"Got: {sign_in_response}"


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens_python/constants.py`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `setup.py`
    -   In `supertokens_python/constants.py`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `supertokens_python/utils.py` file to include that in the `FRAMEWORKS` variable
-   [ ] If added a new recipe that has a User type with extra info, then be sure to change the User type in supertokens_python/types.py
-   [ ] Make sure that `syncio` / `asyncio` functions are consistent.
-   [ ] If access token structure has changed
    -   Modified test in `tests/sessions/test_access_token_version.py` to account for any new claims that are optional or omitted by the core

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
